### PR TITLE
Add starter monorepo skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+.next
+dist
+.env
+.env.local

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "semi": true
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
 # nabd.dhk
+
+This repository contains an all-in-one server setup for **nabd.dhk**.
+It bundles a Next.js front end, a Medusa commerce backend, a Sanity CMS and
+Nginx configuration for deployment on a single droplet.
+
+```
+var/www/
+├── frontend-next/      # Next.js 14 + Tailwind
+├── medusa-backend/     # Medusa commerce API
+├── sanity-studio/      # Sanity Studio v3
+└── server-config/      # Nginx, PM2 and deploy script
+```
+
+## Setup Guide
+
+1. Fill in environment variables in `medusa-backend/.env.template` and copy
+   to `.env`.
+2. Run the one-shot deployment script on your server:
+
+```bash
+sudo bash server-config/deploy.sh
+```
+
+The services will be available at:
+- Frontend: `http://<your-domain>`
+- Medusa API: `http://<your-domain>/api/`
+- Sanity Studio: `http://<your-domain>/studio/`
+
+A sample seed file is included for Medusa in `medusa-backend/data/seed.json`.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./var/www/frontend-next" }
+  ]
+}

--- a/var/www/frontend-next/.eslintrc.json
+++ b/var/www/frontend-next/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/var/www/frontend-next/.prettierrc
+++ b/var/www/frontend-next/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "semi": true
+}

--- a/var/www/frontend-next/Dockerfile
+++ b/var/www/frontend-next/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:20-alpine AS deps
+WORKDIR /app
+COPY package.json ./
+RUN npm install
+
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN npm run build
+
+FROM node:20-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/package.json ./package.json
+COPY --from=builder /app/public ./public
+EXPOSE 3000
+CMD ["npm", "start"]

--- a/var/www/frontend-next/app/cart/page.tsx
+++ b/var/www/frontend-next/app/cart/page.tsx
@@ -1,0 +1,8 @@
+export default function CartPage() {
+  return (
+    <main className="p-8">
+      <h1 className="text-3xl font-bold">Cart</h1>
+      {/* Cart items */}
+    </main>
+  )
+}

--- a/var/www/frontend-next/app/checkout/page.tsx
+++ b/var/www/frontend-next/app/checkout/page.tsx
@@ -1,0 +1,8 @@
+export default function CheckoutPage() {
+  return (
+    <main className="p-8">
+      <h1 className="text-3xl font-bold">Checkout</h1>
+      {/* Checkout form with bKash or COD */}
+    </main>
+  )
+}

--- a/var/www/frontend-next/app/contact/page.tsx
+++ b/var/www/frontend-next/app/contact/page.tsx
@@ -1,0 +1,8 @@
+export default function ContactPage() {
+  return (
+    <main className="p-8">
+      <h1 className="text-3xl font-bold">Contact</h1>
+      {/* Contact form */}
+    </main>
+  )
+}

--- a/var/www/frontend-next/app/globals.css
+++ b/var/www/frontend-next/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/var/www/frontend-next/app/layout.tsx
+++ b/var/www/frontend-next/app/layout.tsx
@@ -1,0 +1,20 @@
+import '../app/globals.css'
+import Navbar from '../components/Navbar'
+import Footer from '../components/Footer'
+
+export const metadata = {
+  title: 'nabd.dhk',
+  description: 'Fashion boutique'
+}
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body className="bg-white text-black">
+        <Navbar />
+        {children}
+        <Footer />
+      </body>
+    </html>
+  )
+}

--- a/var/www/frontend-next/app/page.tsx
+++ b/var/www/frontend-next/app/page.tsx
@@ -1,0 +1,7 @@
+export default function HomePage() {
+  return (
+    <main className="p-8">
+      <h1 className="text-4xl font-bold">nabd.dhk</h1>
+    </main>
+  )
+}

--- a/var/www/frontend-next/app/shop/page.tsx
+++ b/var/www/frontend-next/app/shop/page.tsx
@@ -1,0 +1,8 @@
+export default function ShopPage() {
+  return (
+    <main className="p-8">
+      <h1 className="text-3xl font-bold">Shop</h1>
+      {/* Product grid fetched from Medusa */}
+    </main>
+  )
+}

--- a/var/www/frontend-next/components/CartDrawer.tsx
+++ b/var/www/frontend-next/components/CartDrawer.tsx
@@ -1,0 +1,8 @@
+export default function CartDrawer() {
+  return (
+    <aside className="fixed right-0 top-0 w-80 h-full bg-white shadow-lg p-4">
+      {/* Cart drawer content */}
+      <h2 className="font-bold mb-4">Your Cart</h2>
+    </aside>
+  )
+}

--- a/var/www/frontend-next/components/Footer.tsx
+++ b/var/www/frontend-next/components/Footer.tsx
@@ -1,0 +1,7 @@
+export default function Footer() {
+  return (
+    <footer className="p-4 border-t border-gray-200 text-center text-sm">
+      \u00A9 {new Date().getFullYear()} nabd.dhk
+    </footer>
+  )
+}

--- a/var/www/frontend-next/components/LookbookCarousel.tsx
+++ b/var/www/frontend-next/components/LookbookCarousel.tsx
@@ -1,0 +1,8 @@
+export default function LookbookCarousel() {
+  return (
+    <div className="w-full h-64 bg-gray-200 flex items-center justify-center">
+      {/* TODO: implement carousel */}
+      <span>Lookbook Carousel</span>
+    </div>
+  )
+}

--- a/var/www/frontend-next/components/Navbar.tsx
+++ b/var/www/frontend-next/components/Navbar.tsx
@@ -1,0 +1,12 @@
+export default function Navbar() {
+  return (
+    <nav className="p-4 border-b border-gray-200 flex justify-between">
+      <a href="/" className="font-bold">nabd.dhk</a>
+      <div className="space-x-4">
+        <a href="/shop">Shop</a>
+        <a href="/cart">Cart</a>
+        <a href="/contact">Contact</a>
+      </div>
+    </nav>
+  )
+}

--- a/var/www/frontend-next/lib/medusa.ts
+++ b/var/www/frontend-next/lib/medusa.ts
@@ -1,0 +1,4 @@
+import Medusa from '@medusajs/medusa-js'
+
+const medusaUrl = process.env.NEXT_PUBLIC_MEDUSA_URL || 'http://localhost:7001'
+export const medusa = new Medusa({ baseUrl: medusaUrl, maxRetries: 3 })

--- a/var/www/frontend-next/lib/sanity.ts
+++ b/var/www/frontend-next/lib/sanity.ts
@@ -1,0 +1,8 @@
+import { createClient } from '@sanity/client'
+
+export const sanity = createClient({
+  projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID || '',
+  dataset: 'production',
+  useCdn: true,
+  apiVersion: '2023-05-03'
+})

--- a/var/www/frontend-next/lib/store.ts
+++ b/var/www/frontend-next/lib/store.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand'
+
+interface CartState {
+  items: any[]
+  add: (item: any) => void
+  clear: () => void
+}
+
+export const useCart = create<CartState>((set) => ({
+  items: [],
+  add: (item) => set((state) => ({ items: [...state.items, item] })),
+  clear: () => set({ items: [] })
+}))

--- a/var/www/frontend-next/next-env.d.ts
+++ b/var/www/frontend-next/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/var/www/frontend-next/next.config.js
+++ b/var/www/frontend-next/next.config.js
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    appDir: true
+  },
+  output: 'standalone'
+}
+
+module.exports = nextConfig

--- a/var/www/frontend-next/package.json
+++ b/var/www/frontend-next/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "frontend-next",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.0.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "zustand": "4.4.0",
+    "@medusajs/medusa-js": "^1.2.6",
+    "@sanity/client": "^6.7.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.2.2",
+    "tailwindcss": "^3.3.5",
+    "postcss": "^8.4.31",
+    "autoprefixer": "^10.4.15",
+    "eslint": "^8.53.0",
+    "eslint-config-next": "14.0.0",
+    "prettier": "^2.8.8"
+  }
+}

--- a/var/www/frontend-next/postcss.config.js
+++ b/var/www/frontend-next/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/var/www/frontend-next/public/logo.svg
+++ b/var/www/frontend-next/public/logo.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 20">
+  <text x="0" y="15" font-size="15">nabd.dhk</text>
+</svg>

--- a/var/www/frontend-next/tailwind.config.js
+++ b/var/www/frontend-next/tailwind.config.js
@@ -1,0 +1,20 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './app/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}'
+  ],
+  theme: {
+    extend: {
+      fontFamily: {
+        grotesk: ['Grotesk', 'sans-serif'],
+        arabic: ['ArabicFont', 'sans-serif']
+      },
+      colors: {
+        black: '#000',
+        white: '#fff'
+      }
+    }
+  },
+  plugins: []
+}

--- a/var/www/frontend-next/tsconfig.json
+++ b/var/www/frontend-next/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/var/www/medusa-backend/.env.template
+++ b/var/www/medusa-backend/.env.template
@@ -1,0 +1,13 @@
+NODE_ENV=production
+MEDUSA_ADMIN_CORS=http://localhost:7000
+MEDUSA_STORE_CORS=http://localhost:3000
+DATABASE_URL=postgres://postgres:postgres@localhost:5432/medusa
+REDIS_URL=redis://localhost:6379
+JWT_SECRET=supersecret
+COOKIE_SECRET=supersecretcookie
+BKASH_BASE_URL=https://tokenized.sandbox.bka.sh/v1.2.0-beta
+BKASH_USERNAME=
+BKASH_PASSWORD=
+BKASH_APP_KEY=
+BKASH_APP_SECRET=
+BKASH_CALLBACK_URL=https://example.com/api/bkash/callback

--- a/var/www/medusa-backend/Dockerfile
+++ b/var/www/medusa-backend/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json ./
+RUN npm install
+COPY . .
+CMD ["npm", "start"]

--- a/var/www/medusa-backend/data/seed.json
+++ b/var/www/medusa-backend/data/seed.json
@@ -1,0 +1,23 @@
+{
+  "product": [
+    {
+      "id": "prod-1",
+      "title": "Sample Shirt",
+      "description": "A plain white shirt.",
+      "images": ["https://placehold.co/600x800?text=Shirt"],
+      "options": [{ "title": "Size" }],
+      "variants": [
+        {
+          "title": "S",
+          "prices": [{ "currency_code": "usd", "amount": 2000 }],
+          "options": [{ "value": "S" }]
+        },
+        {
+          "title": "M",
+          "prices": [{ "currency_code": "usd", "amount": 2000 }],
+          "options": [{ "value": "M" }]
+        }
+      ]
+    }
+  ]
+}

--- a/var/www/medusa-backend/docker-compose.yml
+++ b/var/www/medusa-backend/docker-compose.yml
@@ -1,0 +1,25 @@
+version: '3.7'
+services:
+  medusa:
+    build: .
+    command: npm start
+    volumes:
+      - .:/app
+    ports:
+      - '7001:7001'
+    environment:
+      - DATABASE_URL=postgres://postgres:postgres@db:5432/medusa
+      - REDIS_URL=redis://redis:6379
+    depends_on:
+      - db
+      - redis
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_PASSWORD: postgres
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+  redis:
+    image: redis:7
+volumes:
+  postgres-data:

--- a/var/www/medusa-backend/medusa-config.js
+++ b/var/www/medusa-backend/medusa-config.js
@@ -1,0 +1,18 @@
+const dotenv = require('dotenv')
+dotenv.config()
+
+module.exports = {
+  projectConfig: {
+    redis_url: process.env.REDIS_URL,
+    database_url: process.env.DATABASE_URL,
+    jwt_secret: process.env.JWT_SECRET,
+    cookie_secret: process.env.COOKIE_SECRET,
+    store_cors: process.env.MEDUSA_STORE_CORS,
+    admin_cors: process.env.MEDUSA_ADMIN_CORS,
+  },
+  plugins: [
+    './plugins/bkash',
+    './plugins/cod',
+    'medusa-fulfillment-manual'
+  ]
+}

--- a/var/www/medusa-backend/package.json
+++ b/var/www/medusa-backend/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "medusa-backend",
+  "private": true,
+  "scripts": {
+    "start": "medusa start",
+    "seed": "medusa seed -f ./data/seed.json"
+  },
+  "dependencies": {
+    "@medusajs/medusa": "^1.7.3",
+    "medusa-fulfillment-manual": "^1.7.3",
+    "medusa-payment-manual": "^1.7.3",
+    "pg": "^8.11.0",
+    "redis": "^4.6.7"
+  }
+}

--- a/var/www/medusa-backend/plugins/bkash/index.js
+++ b/var/www/medusa-backend/plugins/bkash/index.js
@@ -1,0 +1,22 @@
+class BkashService {
+  static identifier = 'bkash'
+
+  constructor(_, options) {
+    this.options = options
+  }
+
+  async createPayment() {
+    // integrate bKash REST here
+    return { status: 'created' }
+  }
+
+  async authorizePayment() {
+    return { status: 'authorized' }
+  }
+
+  async capturePayment() {
+    return { status: 'captured' }
+  }
+}
+
+module.exports = BkashService

--- a/var/www/medusa-backend/plugins/cod/index.js
+++ b/var/www/medusa-backend/plugins/cod/index.js
@@ -1,0 +1,6 @@
+module.exports = {
+  resolve: 'medusa-payment-manual',
+  options: {
+    automatic_capture: true
+  }
+}

--- a/var/www/sanity-studio/package.json
+++ b/var/www/sanity-studio/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "sanity-studio",
+  "private": true,
+  "scripts": {
+    "dev": "sanity dev",
+    "build": "sanity build",
+    "start": "sanity start"
+  },
+  "dependencies": {
+    "sanity": "^3.18.0",
+    "@sanity/cli": "^3.18.0"
+  }
+}

--- a/var/www/sanity-studio/sanity.config.ts
+++ b/var/www/sanity-studio/sanity.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'sanity'
+import { deskTool } from 'sanity/desk'
+import schemas from './schemas'
+
+export default defineConfig({
+  projectId: 'yourProjectId',
+  dataset: 'production',
+  plugins: [deskTool()],
+  schema: { types: schemas }
+})

--- a/var/www/sanity-studio/schemas/index.ts
+++ b/var/www/sanity-studio/schemas/index.ts
@@ -1,0 +1,5 @@
+import product from './product'
+import lookbookItem from './lookbookItem'
+import siteSettings from './siteSettings'
+
+export default [product, lookbookItem, siteSettings]

--- a/var/www/sanity-studio/schemas/lookbookItem.js
+++ b/var/www/sanity-studio/schemas/lookbookItem.js
@@ -1,0 +1,11 @@
+export default {
+  name: 'lookbookItem',
+  title: 'Lookbook Item',
+  type: 'document',
+  fields: [
+    { name: 'title', title: 'Title', type: 'string' },
+    { name: 'photo', title: 'Photo', type: 'image' },
+    { name: 'season', title: 'Season', type: 'string' },
+    { name: 'order', title: 'Order', type: 'number' }
+  ]
+}

--- a/var/www/sanity-studio/schemas/product.js
+++ b/var/www/sanity-studio/schemas/product.js
@@ -1,0 +1,15 @@
+export default {
+  name: 'product',
+  title: 'Product',
+  type: 'document',
+  fields: [
+    { name: 'title', title: 'Title', type: 'string' },
+    { name: 'slug', title: 'Slug', type: 'slug', options: { source: 'title', maxLength: 96 } },
+    { name: 'price', title: 'Price', type: 'number' },
+    { name: 'sizes', title: 'Sizes', type: 'array', of: [{ type: 'string' }] },
+    { name: 'stock', title: 'Stock', type: 'number' },
+    { name: 'images', title: 'Images', type: 'array', of: [{ type: 'image' }] },
+    { name: 'description', title: 'Description', type: 'text' },
+    { name: 'isFeatured', title: 'Featured', type: 'boolean' }
+  ]
+}

--- a/var/www/sanity-studio/schemas/siteSettings.js
+++ b/var/www/sanity-studio/schemas/siteSettings.js
@@ -1,0 +1,10 @@
+export default {
+  name: 'siteSettings',
+  title: 'Site Settings',
+  type: 'document',
+  fields: [
+    { name: 'heroTagline', title: 'Hero Tagline', type: 'string' },
+    { name: 'contactEmail', title: 'Contact Email', type: 'string' },
+    { name: 'instagramUrl', title: 'Instagram URL', type: 'url' }
+  ]
+}

--- a/var/www/server-config/deploy.sh
+++ b/var/www/server-config/deploy.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -e
+
+sudo apt update
+sudo apt install -y curl nginx docker.io docker-compose certbot python3-certbot-nginx
+
+curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+sudo apt install -y nodejs
+sudo npm install -g yarn pm2
+
+# clone repo assumed already present at /var/www
+cd /var/www/sanity-studio
+yarn install
+yarn build
+
+cd /var/www/medusa-backend
+cp .env.template .env
+sudo docker compose up -d
+
+cd /var/www/frontend-next
+yarn install
+yarn build
+
+sudo ln -sf /var/www/server-config/nginx.conf /etc/nginx/sites-enabled/default
+sudo systemctl restart nginx
+
+sudo certbot --nginx --non-interactive --agree-tos -m you@example.com -d example.com || true
+
+pm2 start /var/www/server-config/pm2-universe.json
+pm2 save

--- a/var/www/server-config/nginx.conf
+++ b/var/www/server-config/nginx.conf
@@ -1,0 +1,22 @@
+server {
+    listen 80;
+    server_name example.com;
+
+    location / {
+        proxy_pass http://localhost:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+    }
+
+    location /api/ {
+        proxy_pass http://localhost:7001/;
+    }
+
+    location /studio/ {
+        alias /var/www/sanity-studio/dist/;
+        try_files $uri $uri/ =404;
+    }
+}

--- a/var/www/server-config/pm2-universe.json
+++ b/var/www/server-config/pm2-universe.json
@@ -1,0 +1,16 @@
+{
+  "apps": [
+    {
+      "name": "frontend",
+      "cwd": "/var/www/frontend-next",
+      "script": "npm",
+      "args": "start"
+    },
+    {
+      "name": "medusa",
+      "cwd": "/var/www/medusa-backend",
+      "script": "npm",
+      "args": "start"
+    }
+  ]
+}

--- a/var/www/server-config/seed.js
+++ b/var/www/server-config/seed.js
@@ -1,0 +1,2 @@
+// Example script to import sample data to Sanity and Medusa
+console.log('Seed script placeholder')


### PR DESCRIPTION
## Summary
- set up directory tree under `var/www`
- add Next.js frontend skeleton with Tailwind and Dockerfile
- add Medusa backend with docker compose and custom plugins
- add Sanity Studio config and schemas
- provide server configs with Nginx, PM2 and deploy script
- update README with setup guide

## Testing
- `npx tsc --noEmit`
- `docker compose -f var/www/medusa-backend/docker-compose.yml config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6887b64607e483219dd155ec7d6e9fc9