### PR TITLE
Fix medusa plugin versions

### DIFF
--- a/var/www/medusa-backend/package.json
+++ b/var/www/medusa-backend/package.json
@@ -7,8 +7,8 @@
   },
   "dependencies": {
     "@medusajs/medusa": "^1.7.8",
-    "medusa-fulfillment-manual": "^1.7.8",
-    "medusa-payment-manual": "^1.7.8",
+    "medusa-fulfillment-manual": "^1.1.41",
+    "medusa-payment-manual": "^1.0.25",
     "pg": "^8.11.0",
     "redis": "^4.6.7"
   }


### PR DESCRIPTION
## Summary
- use correct versions for `medusa-fulfillment-manual` and `medusa-payment-manual`

## Testing
- `npm install` in `var/www/medusa-backend`

------
https://chatgpt.com/codex/tasks/task_b_68887ac2bda883219a173a34908af90f