### PR TITLE
Fix missing dependencies for Medusa backend

### DIFF
--- a/var/www/medusa-backend/package.json
+++ b/var/www/medusa-backend/package.json
@@ -6,6 +6,8 @@
     "seed": "medusa seed -f ./data/seed.json"
   },
   "dependencies": {
+    "@medusajs/cache-inmemory": "^1.8.1",
+    "@medusajs/event-bus-local": "^1.8.0",
     "@medusajs/medusa": "^1.7.8",
     "medusa-fulfillment-manual": "^1.1.41",
     "medusa-payment-manual": "^1.0.25",


### PR DESCRIPTION
## Summary
- add `@medusajs/event-bus-local` and `@medusajs/cache-inmemory` to Medusa backend dependencies

## Testing
- `npm install` in `var/www/medusa-backend`
- `npm start` (fails to connect to database but no missing module errors)

------
https://chatgpt.com/codex/tasks/task_b_688882239ef48321840064316d16ff16