### PR TITLE
Pin typeorm version

### DIFF
--- a/var/www/medusa-backend/package.json
+++ b/var/www/medusa-backend/package.json
@@ -12,6 +12,7 @@
     "medusa-fulfillment-manual": "^1.1.41",
     "medusa-payment-manual": "^1.0.25",
     "pg": "^8.11.0",
-    "redis": "^4.6.7"
+    "redis": "^4.6.7",
+    "typeorm": "0.3.16"
   }
 }


### PR DESCRIPTION
## Summary
- avoid breaking change in TypeORM by pinning its version

## Testing
- `npm start` *(fails to connect to Postgres but proceeds past TypeORM update error)*

------
https://chatgpt.com/codex/tasks/task_b_6888bf7188ac832192ebd045ef6b6507