### PR TITLE
feat: run migrations on startup

### DIFF
--- a/var/www/medusa-backend/Dockerfile
+++ b/var/www/medusa-backend/Dockerfile
@@ -1,6 +1,8 @@
 FROM node:20-alpine
 WORKDIR /app
 COPY package.json ./
-RUN npm install
+RUN npm install && apk add --no-cache postgresql-client
 COPY . .
+RUN chmod +x docker-entrypoint.sh
+ENTRYPOINT ["./docker-entrypoint.sh"]
 CMD ["npm", "start"]

--- a/var/www/medusa-backend/docker-entrypoint.sh
+++ b/var/www/medusa-backend/docker-entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -e
+
+# Wait for Postgres to be ready
+until pg_isready -h db -p 5432 >/dev/null 2>&1; do
+  echo "Waiting for Postgres..."
+  sleep 1
+done
+
+# Create the database if it doesn't exist
+psql postgres://postgres:postgres@db:5432/postgres -tc "SELECT 1 FROM pg_database WHERE datname = 'medusa'" | grep -q 1 || \
+  psql postgres://postgres:postgres@db:5432/postgres -c "CREATE DATABASE medusa"
+
+# Run migrations
+npx medusa migrations run
+
+# Execute the passed command
+exec "$@"

--- a/var/www/medusa-backend/package.json
+++ b/var/www/medusa-backend/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "scripts": {
     "start": "medusa start",
-    "seed": "medusa seed -f ./data/seed.json"
+    "seed": "medusa seed -f ./data/seed.json",
+    "migrate": "medusa migrations run"
   },
   "dependencies": {
     "@medusajs/admin": "^7.1.18",


### PR DESCRIPTION
## Summary
- ensure Postgres is ready and database exists before starting Medusa
- run database migrations automatically at startup
- expose migration script via package.json

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_688b29a8631c8321addfef69c3328a21