### PR TITLE
fix admin plugin path

### DIFF
--- a/var/www/medusa-backend/medusa-config.js
+++ b/var/www/medusa-backend/medusa-config.js
@@ -19,7 +19,7 @@ module.exports = {
       resolve: '@medusajs/admin',
       /** @type {import('@medusajs/admin').PluginOptions} */
       options: {
-        path: 'admin',
+        path: '/admin',
         serve: true,
         autoRebuild: true
       }


### PR DESCRIPTION
## Summary
- fix admin plugin path to include leading slash

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run migrate`
- `npm run seed` *(fails: `'path' in the options of @medusajs/admin must start with a '/'` before fix)*
- `npm start`

------
https://chatgpt.com/codex/tasks/task_b_688b6cc902688321896ac9bb6f920579