### PR TITLE
Fix medusa admin swc on musl

### DIFF
--- a/var/www/medusa-backend/docker-entrypoint.sh
+++ b/var/www/medusa-backend/docker-entrypoint.sh
@@ -11,6 +11,9 @@ done
 psql postgres://postgres:postgres@db:5432/postgres -tc "SELECT 1 FROM pg_database WHERE datname = 'medusa'" | grep -q 1 || \
   psql postgres://postgres:postgres@db:5432/postgres -c "CREATE DATABASE medusa"
 
+# Ensure musl-compatible SWC binary is installed
+npm install @swc/core-linux-x64-musl@1.13.3 --no-save
+
 # Run migrations
 npx medusa migrations run
 


### PR DESCRIPTION
## Summary
- install musl-compatible SWC binary at startup so Admin UI runs on Alpine

## Testing
- `npm test` (fails: missing script)


------
https://chatgpt.com/codex/tasks/task_b_688b7d7e45c483218118f73fdd1bb444