### PR TITLE
fix: route admin traffic in nginx

### DIFF
--- a/var/www/medusa-backend/docker-compose.yml
+++ b/var/www/medusa-backend/docker-compose.yml
@@ -13,6 +13,14 @@ services:
     depends_on:
       - db
       - redis
+  nginx:
+    image: nginx:alpine
+    ports:
+      - '80:80'
+    volumes:
+      - ../server-config/nginx.dev.conf:/etc/nginx/conf.d/default.conf:ro
+    depends_on:
+      - medusa
   db:
     image: postgres:15
     environment:

--- a/var/www/server-config/nginx.conf
+++ b/var/www/server-config/nginx.conf
@@ -15,6 +15,15 @@ server {
         proxy_pass http://localhost:7001/;
     }
 
+    location /admin/ {
+        proxy_pass http://localhost:7001/admin/;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+    }
+
     location /studio/ {
         alias /var/www/sanity-studio/dist/;
         try_files $uri $uri/ =404;

--- a/var/www/server-config/nginx.dev.conf
+++ b/var/www/server-config/nginx.dev.conf
@@ -1,0 +1,16 @@
+server {
+    listen 80;
+
+    location /api/ {
+        proxy_pass http://medusa:7001/;
+    }
+
+    location /admin/ {
+        proxy_pass http://medusa:7001/admin/;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+    }
+}


### PR DESCRIPTION
## Summary
- add docker-specific nginx config that proxies `/admin` to the Medusa service
- run nginx via docker-compose so local admin panel loads after login

## Testing
- `python - <<'PY' import yaml,sys; yaml.safe_load(open('var/www/medusa-backend/docker-compose.yml')); print('OK')\nPY`
- `printf 'events {}\nhttp { include /workspace/nabd.dhk/var/www/server-config/nginx.dev.conf; }' > /tmp/nginx-test.conf`
- `echo '127.0.0.1 medusa' >> /etc/hosts && nginx -t -c /tmp/nginx-test.conf`


------
https://chatgpt.com/codex/tasks/task_b_688bea96eb588321b059f2e92f7a140c