### PR TITLE
fix: install Medusa CLI

### DIFF
--- a/var/www/medusa-backend/Dockerfile
+++ b/var/www/medusa-backend/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:20-alpine
 WORKDIR /app
 COPY package.json ./
-RUN npm install && apk add --no-cache postgresql-client
+RUN npm install -g @medusajs/medusa-cli && npm install && apk add --no-cache postgresql-client
 COPY . .
 RUN chmod +x docker-entrypoint.sh
 ENTRYPOINT ["./docker-entrypoint.sh"]


### PR DESCRIPTION
## Summary
- install @medusajs/medusa-cli globally in Medusa backend Dockerfile to enable `medusa start`

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_b_688bf0eef0cc8321a12f92343601a86d