### PR TITLE
fix medusa container entrypoint

### DIFF
--- a/var/www/medusa-backend/Dockerfile
+++ b/var/www/medusa-backend/Dockerfile
@@ -3,6 +3,8 @@ WORKDIR /app
 COPY package.json ./
 RUN npm install -g @medusajs/medusa-cli && npm install && apk add --no-cache postgresql-client
 COPY . .
-RUN chmod +x docker-entrypoint.sh
-ENTRYPOINT ["./docker-entrypoint.sh"]
+# Normalize line endings and ensure the entrypoint script is executable
+RUN sed -i 's/\r$//' docker-entrypoint.sh && chmod +x docker-entrypoint.sh
+# Use an absolute path when invoking the entrypoint to avoid resolution issues
+ENTRYPOINT ["/bin/sh", "/app/docker-entrypoint.sh"]
 CMD ["npm", "start"]


### PR DESCRIPTION
## Summary
- ensure entrypoint script is copied correctly and invoked via absolute path
- normalize line endings for docker-entrypoint.sh

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_688bffb5d8f88321999f91229a05eb28