### PR TITLE
Fix entrypoint script and Nginx upstream resolution

### DIFF
--- a/var/www/medusa-backend/Dockerfile
+++ b/var/www/medusa-backend/Dockerfile
@@ -5,6 +5,6 @@ RUN npm install -g @medusajs/medusa-cli && npm install && apk add --no-cache pos
 COPY . .
 # Normalize line endings and ensure the entrypoint script is executable
 RUN sed -i 's/\r$//' docker-entrypoint.sh && chmod +x docker-entrypoint.sh
-# Use an absolute path when invoking the entrypoint to avoid resolution issues
-ENTRYPOINT ["/bin/sh", "/app/docker-entrypoint.sh"]
+# Use an absolute path when invoking the entrypoint and enable -e to abort on errors
+ENTRYPOINT ["/bin/sh", "-e", "/app/docker-entrypoint.sh"]
 CMD ["npm", "start"]

--- a/var/www/medusa-backend/docker-entrypoint.sh
+++ b/var/www/medusa-backend/docker-entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
-set -e
+
+# Fail fast if any command exits with a non-zero status. The -e flag is
+# supplied by the Dockerfile's ENTRYPOINT invocation.
 
 # Wait for Postgres to be ready
 until pg_isready -h db -p 5432 >/dev/null 2>&1; do

--- a/var/www/server-config/nginx.dev.conf
+++ b/var/www/server-config/nginx.dev.conf
@@ -1,12 +1,16 @@
 server {
     listen 80;
 
+    # Resolve service names via Docker's internal DNS and defer lookup until request time
+    resolver 127.0.0.11;
+    set $medusa_backend http://medusa:7001;
+
     location /api/ {
-        proxy_pass http://medusa:7001/;
+        proxy_pass $medusa_backend/;
     }
 
     location /admin/ {
-        proxy_pass http://medusa:7001/admin/;
+        proxy_pass $medusa_backend/admin/;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';


### PR DESCRIPTION
## Summary
- ensure docker entrypoint runs with `-e` to prevent illegal option error
- defer Nginx `medusa` host resolution through Docker DNS

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_688c03848d08832197f8f44965f051a1