### PR TITLE
Use npx to invoke Medusa CLI

### DIFF
--- a/var/www/medusa-backend/package.json
+++ b/var/www/medusa-backend/package.json
@@ -2,9 +2,9 @@
   "name": "medusa-backend",
   "private": true,
   "scripts": {
-    "start": "medusa start",
-    "seed": "medusa seed -f ./data/seed.json",
-    "migrate": "medusa migrations run"
+    "start": "npx medusa start",
+    "seed": "npx medusa seed -f ./data/seed.json",
+    "migrate": "npx medusa migrations run"
   },
   "dependencies": {
     "@medusajs/admin": "^7.1.18",


### PR DESCRIPTION
## Summary
- run Medusa CLI via npx in backend scripts to avoid missing command errors

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_b_688c0f5499648321a1f957e8df54645d