### PR TITLE
chore: enforce LF line endings for scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+*.sh text eol=lf


### PR DESCRIPTION
## Summary
- ensure shell scripts are stored with LF endings to avoid Windows-style entrypoint failures

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_688c179f51808321a4bc6fb6bf8c30fc