### PR TITLE
Replace deprecated desk tool

### DIFF
--- a/var/www/sanity-studio/sanity.config.ts
+++ b/var/www/sanity-studio/sanity.config.ts
@@ -1,10 +1,10 @@
-import { defineConfig } from 'sanity'
-import { deskTool } from 'sanity/desk'
-import schemas from './schemas'
+import { defineConfig } from 'sanity';
+import { structureTool } from 'sanity/structure';
+import schemas from './schemas';
 
 export default defineConfig({
   projectId: 'yourProjectId',
   dataset: 'production',
-  plugins: [deskTool()],
-  schema: { types: schemas }
-})
+  plugins: [structureTool()],
+  schema: { types: schemas },
+});


### PR DESCRIPTION
## Summary
- replace deprecated desk tool with `structureTool`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx prettier var/www/sanity-studio/sanity.config.ts --check`

------
https://chatgpt.com/codex/tasks/task_b_688d460d253083219a03806e4ad61d9b