### PR TITLE
fix: correct admin CORS and URLs

### DIFF
--- a/var/www/medusa-backend/.env.template
+++ b/var/www/medusa-backend/.env.template
@@ -1,6 +1,10 @@
 NODE_ENV=production
-MEDUSA_ADMIN_CORS=http://localhost:7000
+# URL where the Medusa Admin runs
+MEDUSA_ADMIN_CORS=http://localhost:7001
 MEDUSA_STORE_CORS=http://localhost:3000
+# Public URLs used by the Admin to talk to the backend
+MEDUSA_BACKEND_URL=http://localhost:9000
+MEDUSA_ADMIN_URL=http://localhost:7001
 DATABASE_URL=postgres://postgres:postgres@db:5432/medusa
 REDIS_URL=redis://redis:6379
 JWT_SECRET=supersecret


### PR DESCRIPTION
## Summary
- set Medusa admin CORS to localhost:7001
- expose backend and admin URLs for admin interface

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_b_688d4d2dd7d48321bc14253bc156f7a7