### PR TITLE
Fix admin login loop by setting backend URL

### DIFF
--- a/var/www/medusa-backend/medusa-config.js
+++ b/var/www/medusa-backend/medusa-config.js
@@ -21,7 +21,13 @@ module.exports = {
       options: {
         path: '/admin',
         serve: true,
-        autoRebuild: true
+        autoRebuild: true,
+        // Ensure the admin UI points to the same backend that
+        // exposes the Medusa API. Without this the UI defaults to
+        // http://localhost:9000 which breaks authentication when the
+        // backend is served on a different port (e.g. 7001 in the
+        // docker-compose setup).
+        backend: process.env.MEDUSA_ADMIN_BACKEND_URL || 'http://localhost:7001'
       }
     }
   ]


### PR DESCRIPTION
## Summary
- ensure admin UI points to correct Medusa backend so authentication works when backend runs on custom port

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_688dc707a58c8321a605646440caff4f