### PR TITLE
fix: serve admin ui on app path

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,15 @@ The services will be available at:
 - Frontend: `http://<your-domain>`
 - Medusa API: `http://<your-domain>/api/`
 - Sanity Studio: `http://<your-domain>/studio/`
-- Medusa Admin: `http://<your-domain>/admin/`
+- Medusa Admin: `http://<your-domain>/app/`
 
 A sample seed file is included for Medusa in `medusa-backend/data/seed.json`.
 
 ## Admin UI
 
-The Medusa backend serves an admin dashboard at `/admin/`. Use this interface to
-manage products, handle orders and track inventory. Custom collections such as
-lookbook images or site settings can be added through Sanity Studio and surfaced
-inside the admin using custom widgets.
+The Medusa backend now serves the admin dashboard at `/app/`. The `/admin/`
+path is reserved for the API itself, so attempting to access the dashboard at
+`/admin` will result in authentication loops. Use `/app/` to manage products,
+handle orders and track inventory. Custom collections such as lookbook images
+or site settings can be added through Sanity Studio and surfaced inside the admin
+using custom widgets.

--- a/var/www/medusa-backend/medusa-config.js
+++ b/var/www/medusa-backend/medusa-config.js
@@ -19,7 +19,11 @@ module.exports = {
       resolve: '@medusajs/admin',
       /** @type {import('@medusajs/admin').PluginOptions} */
       options: {
-        path: '/admin',
+        // Serve the admin dashboard under "/app" to avoid clashing with
+        // Medusa's own "/admin" API routes. Hitting "/admin" now correctly
+        // resolves to the backend API while the UI is available at
+        // "http://<host>:<port>/app".
+        path: '/app',
         serve: true,
         autoRebuild: true,
         // Ensure the admin UI points to the same backend that


### PR DESCRIPTION
## Summary
- serve Medusa admin UI under `/app` so `/admin` route remains API-only
- document new dashboard path in README to prevent login loops

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_688de90acb848321983840b968606531