### PR TITLE
feat: add NABD branding to admin and studio

### DIFF
--- a/var/www/medusa-backend/admin-extensions/index.js
+++ b/var/www/medusa-backend/admin-extensions/index.js
@@ -6,5 +6,17 @@ module.exports = {
       label: 'Lookbook',
       href: '/studio',
     })
+
+    // Add simple NABD branding banner and page title
+    if (typeof document !== 'undefined') {
+      document.title = 'NABD Admin'
+      const banner = document.createElement('div')
+      banner.textContent = 'NABD'
+      banner.style.background = '#222'
+      banner.style.color = '#fff'
+      banner.style.padding = '8px'
+      banner.style.textAlign = 'center'
+      document.body.prepend(banner)
+    }
   },
 }

--- a/var/www/sanity-studio/sanity.config.ts
+++ b/var/www/sanity-studio/sanity.config.ts
@@ -3,6 +3,8 @@ import { structureTool } from 'sanity/structure';
 import schemas from './schemas';
 
 export default defineConfig({
+  name: 'nabd-studio',
+  title: 'NABD Studio',
   projectId: 'yourProjectId',
   dataset: 'production',
   plugins: [structureTool()],


### PR DESCRIPTION
## Summary
- show NABD banner and page title in Medusa admin
- set NABD name and title for Sanity studio

## Testing
- `cd var/www/medusa-backend && npm test` *(fails: Missing script: "test")*
- `cd var/www/sanity-studio && npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_688dfcdb8118832184f774df48325b3d