### PR TITLE
fix: make Sanity client configurable for lookbook data

### DIFF
--- a/var/www/frontend-next/.env.example
+++ b/var/www/frontend-next/.env.example
@@ -1,0 +1,6 @@
+NEXT_PUBLIC_MEDUSA_URL=http://localhost:7001
+NEXT_PUBLIC_SANITY_PROJECT_ID=
+NEXT_PUBLIC_SANITY_DATASET=production
+# Uncomment and add a token if your Sanity dataset is private
+# SANITY_API_READ_TOKEN=
+

--- a/var/www/frontend-next/lib/sanity.ts
+++ b/var/www/frontend-next/lib/sanity.ts
@@ -1,12 +1,15 @@
 import { createClient } from '@sanity/client'
 
 const projectId = process.env.NEXT_PUBLIC_SANITY_PROJECT_ID
+const dataset = process.env.NEXT_PUBLIC_SANITY_DATASET || 'production'
+const token = process.env.SANITY_API_READ_TOKEN
 
 export const sanity = projectId
   ? createClient({
       projectId,
-      dataset: 'production',
-      useCdn: true,
-      apiVersion: '2023-05-03'
+      dataset,
+      apiVersion: '2023-05-03',
+      useCdn: !token,
+      token
     })
-  : { fetch: async () => [] } as any
+  : ({ fetch: async () => [] } as any)


### PR DESCRIPTION
## Summary
- allow dataset and token to be configured for Sanity client
- document required frontend env vars

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_688e0dd3b5a4832186cd8fa27200bbb9