### PR TITLE
Fix admin proxy path and cookie rewrite

### DIFF
--- a/var/www/server-config/nginx.conf
+++ b/var/www/server-config/nginx.conf
@@ -16,7 +16,8 @@ server {
     }
 
     location /admin/ {
-        proxy_pass http://localhost:7001/admin/;
+        proxy_pass http://localhost:7001/app/;
+        proxy_cookie_path /app/ /admin/;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';

--- a/var/www/server-config/nginx.dev.conf
+++ b/var/www/server-config/nginx.dev.conf
@@ -10,7 +10,8 @@ server {
     }
 
     location /admin/ {
-        proxy_pass $medusa_backend/admin/;
+        proxy_pass $medusa_backend/app/;
+        proxy_cookie_path /app/ /admin/;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';


### PR DESCRIPTION
## Summary
- proxy `/admin/` requests to Medusa admin app mounted at `/app/`
- rewrite admin session cookie path so browser sessions persist

## Testing
- `nginx -t -c /workspace/nabd.dhk/var/www/server-config/nginx.conf` *(fails: "server" directive is not allowed here)*
- `nginx -t -c /workspace/nabd.dhk/var/www/server-config/nginx.dev.conf` *(fails: "server" directive is not allowed here)*

------
https://chatgpt.com/codex/tasks/task_b_68913b725ff88321b78b3239931c80ce