### PR TITLE
feat: add product detail page

### DIFF
--- a/var/www/frontend-next/app/product/[id]/page.tsx
+++ b/var/www/frontend-next/app/product/[id]/page.tsx
@@ -1,0 +1,58 @@
+'use client'
+import { useEffect, useState } from 'react'
+import { medusa } from '../../../lib/medusa'
+import { useCart } from '../../../lib/store'
+
+interface Product {
+  id: string
+  title: string
+  description: string
+  images: { url: string }[]
+  price: number
+}
+
+export default function ProductPage({ params }: { params: { id: string } }) {
+  const { id } = params
+  const [product, setProduct] = useState<Product | null>(null)
+  const add = useCart((state) => state.add)
+
+  useEffect(() => {
+    medusa.products.retrieve(id).then(({ product }) => {
+      setProduct({
+        id: product.id,
+        title: product.title,
+        description: product.description,
+        images: product.images || [],
+        price: product.variants[0]?.prices[0]?.amount / 100 || 0
+      })
+    })
+  }, [id])
+
+  if (!product) {
+    return <main className="p-8">Loading...</main>
+  }
+
+  return (
+    <main className="p-8">
+      <div className="flex flex-col md:flex-row gap-8">
+        <div className="flex-1 space-y-4">
+          {product.images.map((img, i) => (
+            <img key={i} src={img.url} alt={product.title} className="w-full object-cover" />
+          ))}
+        </div>
+        <div className="flex-1 space-y-4">
+          <h1 className="text-3xl font-bold tracking-wider">{product.title}</h1>
+          <p>{product.description}</p>
+          <p className="text-xl font-semibold">${product.price.toFixed(2)}</p>
+          <button
+            className="px-4 py-2 bg-black text-white"
+            onClick={() => add({ title: product.title, price: product.price })}
+          >
+            Add to cart
+          </button>
+        </div>
+      </div>
+    </main>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add product detail page for viewing and purchasing items

## Testing
- `npm test` *(fails: Missing script 'test')*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_689365cd104883218dba680bdaf75b09