### PR TITLE
Fetch site settings for hero and contact pages

### DIFF
--- a/var/www/frontend-next/app/contact/page.tsx
+++ b/var/www/frontend-next/app/contact/page.tsx
@@ -1,7 +1,44 @@
-export default function ContactPage() {
+import { sanity } from '../../lib/sanity'
+
+export default async function ContactPage() {
+  const siteSettings =
+    (await sanity.fetch(
+      `*[_type == "siteSettings"][0]{contactEmail, instagramUrl}`
+    )) || {}
+
+  const { contactEmail, instagramUrl } = siteSettings as {
+    contactEmail?: string
+    instagramUrl?: string
+  }
+
   return (
     <main className="p-8 space-y-4">
       <h1 className="text-3xl font-bold mb-4 tracking-wider">Contact</h1>
+      <div className="space-y-2">
+        <p>
+          {contactEmail ? (
+            <a href={`mailto:${contactEmail}`} className="underline">
+              {contactEmail}
+            </a>
+          ) : (
+            'Email not available'
+          )}
+        </p>
+        <p>
+          {instagramUrl ? (
+            <a
+              href={instagramUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline"
+            >
+              Instagram
+            </a>
+          ) : (
+            'Instagram not available'
+          )}
+        </p>
+      </div>
       <form className="space-y-4 max-w-md">
         <input type="email" placeholder="Email" className="w-full border p-2" />
         <textarea placeholder="Message" className="w-full border p-2" rows={4} />

--- a/var/www/frontend-next/app/page.tsx
+++ b/var/www/frontend-next/app/page.tsx
@@ -1,9 +1,22 @@
 import LookbookCarousel from '../components/LookbookCarousel'
 import FeaturedProducts from '../components/FeaturedProducts'
+import { sanity } from '../lib/sanity'
 
-export default function HomePage() {
+export default async function HomePage() {
+  const siteSettings =
+    (await sanity.fetch(
+      `*[_type == "siteSettings"][0]{heroTagline}`
+    )) || {}
+
+  const heroTagline = siteSettings.heroTagline || ''
+
   return (
     <main>
+      {heroTagline && (
+        <section className="py-12 text-center bg-gray-100">
+          <h1 className="text-3xl font-bold tracking-wider">{heroTagline}</h1>
+        </section>
+      )}
       <LookbookCarousel />
       <section className="container mx-auto px-4">
         <h2 className="text-2xl font-bold mt-8 mb-4 tracking-wider">Featured products</h2>


### PR DESCRIPTION
## Summary
- load `siteSettings` from Sanity on the home page and display the hero tagline with a fallback
- fetch contact email and Instagram link for the contact page, falling back when missing

## Testing
- `npm test` (fails: Missing script `test`)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_689365e2ffdc83218c7c3bd406aa42a5