### PR TITLE
chore: drop experimental product schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ var/www/
 └── server-config/      # Nginx, PM2 and deploy script
 ```
 
+> **Note**
+>
+> The Sanity schema at `sanity-studio/schemas/product.js` is experimental and
+> currently omitted from `schemas/index.ts`. It will remain excluded until the
+> mapping to the Medusa backend is finalized.
+
 ## Setup Guide
 
 1. Fill in environment variables in `medusa-backend/.env.template` and copy

--- a/var/www/sanity-studio/schemas/index.ts
+++ b/var/www/sanity-studio/schemas/index.ts
@@ -1,5 +1,4 @@
-import product from './product'
 import lookbookItem from './lookbookItem'
 import siteSettings from './siteSettings'
 
-export default [product, lookbookItem, siteSettings]
+export default [lookbookItem, siteSettings]


### PR DESCRIPTION
## Summary
- remove product schema from Sanity index
- clarify experimental product schema in README

## Testing
- `cd var/www/sanity-studio && npm run build`

------
https://chatgpt.com/codex/tasks/task_b_689365e5bfa88321ad33ad335e2325d0