### PR TITLE
feat: support png logo and enlarge lookbook

### DIFF
--- a/var/www/frontend-next/components/LookbookCarousel.tsx
+++ b/var/www/frontend-next/components/LookbookCarousel.tsx
@@ -23,12 +23,12 @@ export default function LookbookCarousel() {
 
   if (items.length === 0) {
     return (
-      <div className="w-full h-64 bg-gray-200 flex items-center justify-center">Loading...</div>
+      <div className="w-full h-[600px] bg-gray-200 flex items-center justify-center">Loading...</div>
     )
   }
 
   return (
-    <Swiper loop className="w-full h-[400px]">
+    <Swiper loop className="w-full h-[600px]">
       {items.map((item) => (
         <SwiperSlide key={item.title}>
           <div className="relative w-full h-full">

--- a/var/www/frontend-next/components/Navbar.tsx
+++ b/var/www/frontend-next/components/Navbar.tsx
@@ -9,7 +9,9 @@ export default function Navbar() {
 
   return (
     <nav className="sticky top-0 z-50 bg-white border-b border-gray-200 px-4 py-3 flex items-center justify-between">
-      <a href="/" className="font-bold text-lg tracking-wider">nabd.dhk</a>
+      <a href="/" className="flex items-center">
+        <img src="/logo.png" alt="nabd.dhk logo" className="h-8 w-auto" />
+      </a>
 
       <button className="md:hidden" onClick={() => setOpen(!open)}>
         {open ? <FaTimes /> : <FaBars />}

--- a/var/www/frontend-next/public/logo.svg
+++ b/var/www/frontend-next/public/logo.svg
@@ -1,3 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 20">
-  <text x="0" y="15" font-size="15">nabd.dhk</text>
-</svg>


### PR DESCRIPTION
## Summary
- switch navbar to use a `logo.png` asset
- increase lookbook carousel height for better image fit
- remove placeholder logo so `public/` remains empty

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_689458f37f74832186c55701a6f4ec76