### PR TITLE
feat: track cart quantities and totals

### DIFF
--- a/var/www/frontend-next/app/cart/page.tsx
+++ b/var/www/frontend-next/app/cart/page.tsx
@@ -2,7 +2,7 @@
 import { useCart } from '../../lib/store'
 
 export default function CartPage() {
-  const { items, clear } = useCart()
+  const { items, clear, updateQuantity, totalItems, totalPrice } = useCart()
 
   return (
     <main className="p-8 space-y-4">
@@ -12,12 +12,26 @@ export default function CartPage() {
       ) : (
         <div className="space-y-2">
           {items.map((item, i) => (
-            <div key={i} className="flex justify-between border-b pb-2">
+            <div key={i} className="grid grid-cols-4 gap-4 items-center border-b pb-2">
               <span>{item.title}</span>
+              <input
+                type="number"
+                min={1}
+                value={item.quantity}
+                onChange={(e) => updateQuantity(item.id, parseInt(e.target.value))}
+                className="w-16 border p-1"
+              />
               <span>${item.price}</span>
+              <span className="text-right">${(item.price * item.quantity).toFixed(2)}</span>
             </div>
           ))}
-          <button className="mt-4 px-4 py-2 bg-black text-white" onClick={clear}>Clear cart</button>
+          <div className="flex justify-between font-semibold pt-2">
+            <span>Subtotal ({totalItems()} items)</span>
+            <span>${totalPrice().toFixed(2)}</span>
+          </div>
+          <button className="mt-4 px-4 py-2 bg-black text-white" onClick={clear}>
+            Clear cart
+          </button>
         </div>
       )}
     </main>

--- a/var/www/frontend-next/app/product/[id]/page.tsx
+++ b/var/www/frontend-next/app/product/[id]/page.tsx
@@ -14,6 +14,7 @@ interface Product {
 export default function ProductPage({ params }: { params: { id: string } }) {
   const { id } = params
   const [product, setProduct] = useState<Product | null>(null)
+  const [quantity, setQuantity] = useState(1)
   const add = useCart((state) => state.add)
 
   useEffect(() => {
@@ -44,12 +45,23 @@ export default function ProductPage({ params }: { params: { id: string } }) {
           <h1 className="text-3xl font-bold tracking-wider">{product.title}</h1>
           <p>{product.description}</p>
           <p className="text-xl font-semibold">${product.price.toFixed(2)}</p>
-          <button
-            className="px-4 py-2 bg-black text-white"
-            onClick={() => add({ title: product.title, price: product.price })}
-          >
-            Add to cart
-          </button>
+          <div className="flex items-center gap-2">
+            <input
+              type="number"
+              min={1}
+              value={quantity}
+              onChange={(e) => setQuantity(parseInt(e.target.value))}
+              className="w-16 border p-1"
+            />
+            <button
+              className="px-4 py-2 bg-black text-white"
+              onClick={() =>
+                add({ id: product.id, title: product.title, price: product.price, quantity })
+              }
+            >
+              Add to cart
+            </button>
+          </div>
         </div>
       </div>
     </main>

--- a/var/www/frontend-next/components/CartDrawer.tsx
+++ b/var/www/frontend-next/components/CartDrawer.tsx
@@ -2,22 +2,30 @@
 import { useCart } from '../lib/store'
 
 export default function CartDrawer() {
-  const { items } = useCart()
+  const { items, totalItems, totalPrice } = useCart()
 
   return (
-    <aside className="fixed right-0 top-0 w-80 h-full bg-white shadow-lg p-4">
-      <h2 className="font-bold mb-4">Your Cart</h2>
+    <aside className="fixed right-0 top-0 w-80 h-full bg-white shadow-lg p-4 space-y-4">
+      <h2 className="font-bold">Your Cart ({totalItems()} items)</h2>
       {items.length === 0 ? (
         <p>Shopping cart is empty!</p>
       ) : (
-        <ul className="space-y-2">
-          {items.map((item, i) => (
-            <li key={i} className="flex justify-between">
-              <span>{item.title}</span>
-              <span>${item.price}</span>
-            </li>
-          ))}
-        </ul>
+        <>
+          <ul className="space-y-2">
+            {items.map((item, i) => (
+              <li key={i} className="flex justify-between">
+                <span>
+                  {item.title} x {item.quantity}
+                </span>
+                <span>${(item.price * item.quantity).toFixed(2)}</span>
+              </li>
+            ))}
+          </ul>
+          <div className="flex justify-between font-semibold border-t pt-2">
+            <span>Subtotal</span>
+            <span>${totalPrice().toFixed(2)}</span>
+          </div>
+        </>
       )}
     </aside>
   )

--- a/var/www/frontend-next/components/Navbar.tsx
+++ b/var/www/frontend-next/components/Navbar.tsx
@@ -5,7 +5,7 @@ import { useCart } from '../lib/store'
 
 export default function Navbar() {
   const [open, setOpen] = useState(false)
-  const { items } = useCart()
+  const itemCount = useCart((state) => state.totalItems())
 
   return (
     <nav className="sticky top-0 z-50 bg-white border-b border-gray-200 px-4 py-3 flex items-center justify-between">
@@ -30,8 +30,8 @@ export default function Navbar() {
       <div className="hidden md:flex items-center gap-4">
         <a href="/cart" className="relative">
           <FaShoppingBag />
-          {items.length > 0 && (
-            <span className="absolute -top-2 -right-2 bg-black text-white text-xs rounded-full px-1">{items.length}</span>
+          {itemCount > 0 && (
+            <span className="absolute -top-2 -right-2 bg-black text-white text-xs rounded-full px-1">{itemCount}</span>
           )}
         </a>
         <a href="/login">

--- a/var/www/frontend-next/lib/store.ts
+++ b/var/www/frontend-next/lib/store.ts
@@ -1,13 +1,48 @@
 import { create } from 'zustand'
+import { persist } from 'zustand/middleware/persist'
 
-interface CartState {
-  items: any[]
-  add: (item: any) => void
-  clear: () => void
+interface CartItem {
+  id: string
+  title: string
+  price: number
+  quantity: number
 }
 
-export const useCart = create<CartState>((set) => ({
-  items: [],
-  add: (item) => set((state) => ({ items: [...state.items, item] })),
-  clear: () => set({ items: [] })
-}))
+interface CartState {
+  items: CartItem[]
+  add: (item: CartItem) => void
+  updateQuantity: (id: string, quantity: number) => void
+  clear: () => void
+  totalItems: () => number
+  totalPrice: () => number
+}
+
+export const useCart = create<CartState>()(
+  persist(
+    (set, get) => ({
+      items: [],
+      add: (item) =>
+        set((state) => {
+          const existing = state.items.find((i) => i.id === item.id)
+          if (existing) {
+            return {
+              items: state.items.map((i) =>
+                i.id === item.id ? { ...i, quantity: i.quantity + item.quantity } : i
+              )
+            }
+          }
+          return { items: [...state.items, item] }
+        }),
+      updateQuantity: (id, quantity) =>
+        set((state) => ({
+          items: state.items
+            .map((i) => (i.id === id ? { ...i, quantity } : i))
+            .filter((i) => i.quantity > 0)
+        })),
+      clear: () => set({ items: [] }),
+      totalItems: () => get().items.reduce((sum, i) => sum + i.quantity, 0),
+      totalPrice: () => get().items.reduce((sum, i) => sum + i.price * i.quantity, 0)
+    }),
+    { name: 'cart' }
+  )
+)


### PR DESCRIPTION
## Summary
- persist cart state with quantity-aware items and helpers
- allow selecting item quantities and show cart subtotal
- surface cart totals in drawer and navbar

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6894609e7c3c832181c65d006906cfcb