### PR TITLE
Add shop filtering options

### DIFF
--- a/var/www/frontend-next/app/shop/page.tsx
+++ b/var/www/frontend-next/app/shop/page.tsx
@@ -1,10 +1,66 @@
+import { useEffect, useState } from 'react'
 import ProductGrid from '../../components/ProductGrid'
+import { medusa } from '../../lib/medusa'
+
+interface Category {
+  id: string
+  name: string
+}
 
 export default function ShopPage() {
+  const [categories, setCategories] = useState<Category[]>([])
+  const [category, setCategory] = useState('')
+  const [order, setOrder] = useState('')
+  const [search, setSearch] = useState('')
+
+  useEffect(() => {
+    medusa.productCategories.list().then(({ product_categories }) => {
+      setCategories(product_categories)
+    })
+  }, [])
+
   return (
     <main className="p-8">
       <h1 className="text-3xl font-bold mb-4 tracking-wider">Shop</h1>
-      <ProductGrid />
+
+      <div className="flex flex-col md:flex-row gap-4 mb-6">
+        <select
+          value={category}
+          onChange={(e) => setCategory(e.target.value)}
+          className="border p-2 rounded"
+        >
+          <option value="">All Categories</option>
+          {categories.map((c) => (
+            <option key={c.id} value={c.id}>
+              {c.name}
+            </option>
+          ))}
+        </select>
+
+        <select
+          value={order}
+          onChange={(e) => setOrder(e.target.value)}
+          className="border p-2 rounded"
+        >
+          <option value="">Sort By</option>
+          <option value="price">Price: Low to High</option>
+          <option value="-price">Price: High to Low</option>
+        </select>
+
+        <input
+          type="text"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search products..."
+          className="border p-2 rounded flex-1"
+        />
+      </div>
+
+      <ProductGrid
+        categoryId={category || undefined}
+        order={order || undefined}
+        search={search || undefined}
+      />
     </main>
   )
 }

--- a/var/www/frontend-next/components/ProductGrid.tsx
+++ b/var/www/frontend-next/components/ProductGrid.tsx
@@ -9,11 +9,26 @@ interface Product {
   price: number
 }
 
-export default function ProductGrid() {
+interface ProductGridProps {
+  categoryId?: string
+  order?: string
+  search?: string
+}
+
+export default function ProductGrid({
+  categoryId,
+  order,
+  search
+}: ProductGridProps) {
   const [products, setProducts] = useState<Product[]>([])
 
   useEffect(() => {
-    medusa.products.list().then(({ products }) => {
+    const params: any = {}
+    if (categoryId) params.category_id = categoryId
+    if (order) params.order = order
+    if (search) params.q = search
+
+    medusa.products.list(params).then(({ products }) => {
       const mapped = products.map((p: any) => ({
         id: p.id,
         title: p.title,
@@ -22,7 +37,7 @@ export default function ProductGrid() {
       }))
       setProducts(mapped)
     })
-  }, [])
+  }, [categoryId, order, search])
 
   return (
     <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6 py-8">


### PR DESCRIPTION
## Summary
- Add category, sort, and search controls to shop page
- Allow ProductGrid to accept filter parameters and query Medusa accordingly

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_689460a5973c8321a7778b17b13035ea