### PR TITLE
feat: make lookbook carousel responsive

### DIFF
--- a/var/www/frontend-next/components/LookbookCarousel.tsx
+++ b/var/www/frontend-next/components/LookbookCarousel.tsx
@@ -23,21 +23,21 @@ export default function LookbookCarousel() {
 
   if (items.length === 0) {
     return (
-      <div className="w-full h-[600px] bg-gray-200 flex items-center justify-center">Loading...</div>
+      <div className="w-full h-[400px] md:h-[600px] bg-gray-200 flex items-center justify-center">Loading...</div>
     )
   }
 
   return (
-    <Swiper loop className="w-full h-[600px]">
+    <Swiper loop className="w-full h-[400px] md:h-[600px]">
       {items.map((item) => (
         <SwiperSlide key={item.title}>
           <div className="relative w-full h-full">
-            <img src={item.url} alt={item.title} className="object-cover w-full h-full" />
+            <img src={item.url} alt={item.title} className="object-cover w-full h-full aspect-[3/4]" />
             <div className="absolute inset-0 bg-black/40 flex flex-col items-center justify-center text-white">
-              <h2 className="text-4xl font-bold mb-4 tracking-wider">
+              <h2 className="text-2xl md:text-4xl font-bold mb-4 tracking-wider">
                 {item.season} Lookbook
               </h2>
-              <a href="/shop" className="px-4 py-2 bg-white text-black font-semibold">Shop now</a>
+              <a href="/shop" className="px-4 py-2 bg-white text-black font-semibold text-sm md:text-base">Shop now</a>
             </div>
           </div>
         </SwiperSlide>


### PR DESCRIPTION
## Summary
- add responsive height classes and image aspect ratio to lookbook carousel
- tweak overlay text with mobile-friendly sizing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: TypeError: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_b_689460be9e3c83219556199a9d3c601d