### PR TITLE
feat: add brand theme tokens

### DIFF
--- a/var/www/frontend-next/app/cart/page.tsx
+++ b/var/www/frontend-next/app/cart/page.tsx
@@ -5,19 +5,19 @@ export default function CartPage() {
   const { items, clear } = useCart()
 
   return (
-    <main className="p-8 space-y-4">
-      <h1 className="text-3xl font-bold mb-4 tracking-wider">Cart</h1>
+    <main className="p-xl space-y-md">
+      <h1 className="text-3xl font-bold mb-md tracking-wider">Cart</h1>
       {items.length === 0 ? (
         <p>Shopping cart is empty!</p>
       ) : (
-        <div className="space-y-2">
+        <div className="space-y-xs">
           {items.map((item, i) => (
-            <div key={i} className="flex justify-between border-b pb-2">
+            <div key={i} className="flex justify-between border-b pb-xs">
               <span>{item.title}</span>
               <span>${item.price}</span>
             </div>
           ))}
-          <button className="mt-4 px-4 py-2 bg-black text-white" onClick={clear}>Clear cart</button>
+          <button className="mt-md px-md py-xs bg-brand-primary text-white" onClick={clear}>Clear cart</button>
         </div>
       )}
     </main>

--- a/var/www/frontend-next/app/checkout/page.tsx
+++ b/var/www/frontend-next/app/checkout/page.tsx
@@ -1,15 +1,15 @@
 export default function CheckoutPage() {
   return (
-    <main className="p-8 space-y-4">
-      <h1 className="text-3xl font-bold mb-4 tracking-wider">Checkout</h1>
-      <form className="space-y-4 max-w-md">
-        <input type="text" placeholder="Name" className="w-full border p-2" />
-        <input type="text" placeholder="Address" className="w-full border p-2" />
-        <select className="w-full border p-2">
+    <main className="p-xl space-y-md">
+      <h1 className="text-3xl font-bold mb-md tracking-wider">Checkout</h1>
+      <form className="space-y-md max-w-md">
+        <input type="text" placeholder="Name" className="w-full border p-xs" />
+        <input type="text" placeholder="Address" className="w-full border p-xs" />
+        <select className="w-full border p-xs">
           <option value="bkash">bKash</option>
           <option value="cod">Cash on Delivery</option>
         </select>
-        <button type="submit" className="w-full bg-black text-white py-2">Place order</button>
+        <button type="submit" className="w-full bg-brand-primary text-white py-xs">Place order</button>
       </form>
     </main>
   )

--- a/var/www/frontend-next/app/contact/page.tsx
+++ b/var/www/frontend-next/app/contact/page.tsx
@@ -12,9 +12,9 @@ export default async function ContactPage() {
   }
 
   return (
-    <main className="p-8 space-y-4">
-      <h1 className="text-3xl font-bold mb-4 tracking-wider">Contact</h1>
-      <div className="space-y-2">
+    <main className="p-xl space-y-md">
+      <h1 className="text-3xl font-bold mb-md tracking-wider">Contact</h1>
+      <div className="space-y-xs">
         <p>
           {contactEmail ? (
             <a href={`mailto:${contactEmail}`} className="underline">
@@ -39,10 +39,10 @@ export default async function ContactPage() {
           )}
         </p>
       </div>
-      <form className="space-y-4 max-w-md">
-        <input type="email" placeholder="Email" className="w-full border p-2" />
-        <textarea placeholder="Message" className="w-full border p-2" rows={4} />
-        <button className="bg-black text-white px-4 py-2" type="submit">Send</button>
+      <form className="space-y-md max-w-md">
+        <input type="email" placeholder="Email" className="w-full border p-xs" />
+        <textarea placeholder="Message" className="w-full border p-xs" rows={4} />
+        <button className="bg-brand-primary text-white px-md py-xs" type="submit">Send</button>
       </form>
     </main>
   )

--- a/var/www/frontend-next/app/globals.css
+++ b/var/www/frontend-next/app/globals.css
@@ -7,6 +7,17 @@
     scroll-behavior: smooth;
   }
   body {
-    @apply font-grotesk bg-white text-black;
+    @apply font-grotesk bg-white text-brand-primary;
+  }
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    @apply font-grotesk;
+  }
+  [lang='ar'] {
+    @apply font-arabic;
   }
 }

--- a/var/www/frontend-next/app/layout.tsx
+++ b/var/www/frontend-next/app/layout.tsx
@@ -10,7 +10,7 @@ export const metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body className="bg-white text-black font-grotesk min-h-screen flex flex-col">
+      <body className="bg-white text-brand-primary font-grotesk min-h-screen flex flex-col">
         <Navbar />
         <main className="flex-grow">{children}</main>
         <Footer />

--- a/var/www/frontend-next/app/page.tsx
+++ b/var/www/frontend-next/app/page.tsx
@@ -13,13 +13,13 @@ export default async function HomePage() {
   return (
     <main>
       {heroTagline && (
-        <section className="py-12 text-center bg-gray-100">
+        <section className="py-2xl text-center bg-gray-100">
           <h1 className="text-3xl font-bold tracking-wider">{heroTagline}</h1>
         </section>
       )}
       <LookbookCarousel />
-      <section className="container mx-auto px-4">
-        <h2 className="text-2xl font-bold mt-8 mb-4 tracking-wider">Featured products</h2>
+      <section className="container mx-auto px-md">
+        <h2 className="text-2xl font-bold mt-xl mb-md tracking-wider">Featured products</h2>
         <FeaturedProducts />
       </section>
     </main>

--- a/var/www/frontend-next/app/product/[id]/page.tsx
+++ b/var/www/frontend-next/app/product/[id]/page.tsx
@@ -29,23 +29,23 @@ export default function ProductPage({ params }: { params: { id: string } }) {
   }, [id])
 
   if (!product) {
-    return <main className="p-8">Loading...</main>
+    return <main className="p-xl">Loading...</main>
   }
 
   return (
-    <main className="p-8">
-      <div className="flex flex-col md:flex-row gap-8">
-        <div className="flex-1 space-y-4">
+    <main className="p-xl">
+      <div className="flex flex-col md:flex-row gap-xl">
+        <div className="flex-1 space-y-md">
           {product.images.map((img, i) => (
             <img key={i} src={img.url} alt={product.title} className="w-full object-cover" />
           ))}
         </div>
-        <div className="flex-1 space-y-4">
+        <div className="flex-1 space-y-md">
           <h1 className="text-3xl font-bold tracking-wider">{product.title}</h1>
           <p>{product.description}</p>
           <p className="text-xl font-semibold">${product.price.toFixed(2)}</p>
           <button
-            className="px-4 py-2 bg-black text-white"
+            className="px-md py-xs bg-brand-primary text-white"
             onClick={() => add({ title: product.title, price: product.price })}
           >
             Add to cart

--- a/var/www/frontend-next/app/shop/page.tsx
+++ b/var/www/frontend-next/app/shop/page.tsx
@@ -2,8 +2,8 @@ import ProductGrid from '../../components/ProductGrid'
 
 export default function ShopPage() {
   return (
-    <main className="p-8">
-      <h1 className="text-3xl font-bold mb-4 tracking-wider">Shop</h1>
+    <main className="p-xl">
+      <h1 className="text-3xl font-bold mb-md tracking-wider">Shop</h1>
       <ProductGrid />
     </main>
   )

--- a/var/www/frontend-next/components/CartDrawer.tsx
+++ b/var/www/frontend-next/components/CartDrawer.tsx
@@ -5,12 +5,12 @@ export default function CartDrawer() {
   const { items } = useCart()
 
   return (
-    <aside className="fixed right-0 top-0 w-80 h-full bg-white shadow-lg p-4">
-      <h2 className="font-bold mb-4">Your Cart</h2>
+    <aside className="fixed right-0 top-0 w-80 h-full bg-white shadow-lg p-md">
+      <h2 className="font-bold mb-md">Your Cart</h2>
       {items.length === 0 ? (
         <p>Shopping cart is empty!</p>
       ) : (
-        <ul className="space-y-2">
+        <ul className="space-y-xs">
           {items.map((item, i) => (
             <li key={i} className="flex justify-between">
               <span>{item.title}</span>

--- a/var/www/frontend-next/components/FeaturedProducts.tsx
+++ b/var/www/frontend-next/components/FeaturedProducts.tsx
@@ -25,13 +25,13 @@ export default function FeaturedProducts() {
   }, [])
 
   return (
-    <div className="grid grid-cols-2 md:grid-cols-4 gap-4 py-8">
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-md py-xl">
       {products.map((p) => (
         <a key={p.id} href={`/product/${p.id}`} className="group block">
           <div className="overflow-hidden">
             <img src={p.thumbnail} className="object-cover w-full h-48 group-hover:scale-105 transition-transform" />
           </div>
-          <div className="mt-2 text-sm">
+          <div className="mt-xs text-sm">
             <h3>{p.title}</h3>
             <p className="font-semibold">${p.price.toFixed(2)}</p>
           </div>

--- a/var/www/frontend-next/components/Footer.tsx
+++ b/var/www/frontend-next/components/Footer.tsx
@@ -1,10 +1,10 @@
 export default function Footer() {
   return (
-    <footer className="border-t border-gray-200 text-center text-sm p-8 space-y-4">
+    <footer className="border-t border-gray-200 text-center text-sm p-xl space-y-md">
       <p className="max-w-xl mx-auto">
         Drawing inspiration from contemporary global trends, we create timeless pieces with impeccable craftsmanship, proudly produced right here at home
       </p>
-      <nav className="flex justify-center space-x-6 text-gray-600">
+      <nav className="flex justify-center space-x-6 text-brand-secondary">
         <a href="/story">About</a>
         <a href="/terms">Terms & Conditions</a>
         <a href="/privacy">Privacy Policy</a>

--- a/var/www/frontend-next/components/LookbookCarousel.tsx
+++ b/var/www/frontend-next/components/LookbookCarousel.tsx
@@ -33,11 +33,11 @@ export default function LookbookCarousel() {
         <SwiperSlide key={item.title}>
           <div className="relative w-full h-full">
             <img src={item.url} alt={item.title} className="object-cover w-full h-full" />
-            <div className="absolute inset-0 bg-black/40 flex flex-col items-center justify-center text-white">
-              <h2 className="text-4xl font-bold mb-4 tracking-wider">
+            <div className="absolute inset-0 bg-brand-primary/40 flex flex-col items-center justify-center text-white">
+              <h2 className="text-4xl font-bold mb-md tracking-wider">
                 {item.season} Lookbook
               </h2>
-              <a href="/shop" className="px-4 py-2 bg-white text-black font-semibold">Shop now</a>
+              <a href="/shop" className="px-md py-xs bg-white text-brand-primary font-semibold">Shop now</a>
             </div>
           </div>
         </SwiperSlide>

--- a/var/www/frontend-next/components/Navbar.tsx
+++ b/var/www/frontend-next/components/Navbar.tsx
@@ -8,7 +8,7 @@ export default function Navbar() {
   const { items } = useCart()
 
   return (
-    <nav className="sticky top-0 z-50 bg-white border-b border-gray-200 px-4 py-3 flex items-center justify-between">
+    <nav className="sticky top-0 z-50 bg-white border-b border-gray-200 px-md py-sm flex items-center justify-between">
       <a href="/" className="flex items-center">
         <img src="/logo.png" alt="nabd.dhk logo" className="h-8 w-auto" />
       </a>
@@ -17,7 +17,7 @@ export default function Navbar() {
         {open ? <FaTimes /> : <FaBars />}
       </button>
 
-      <div className={`flex-col md:flex-row md:flex gap-6 ${open ? 'flex' : 'hidden'} md:items-center`}>
+      <div className={`flex-col md:flex-row md:flex gap-lg ${open ? 'flex' : 'hidden'} md:items-center`}>
         <a href="/">Home</a>
         <a href="/shop">Shop</a>
         <a href="/contact">Contact</a>
@@ -27,11 +27,11 @@ export default function Navbar() {
         <a href="/shop?category=UNISEX">UNISEX</a>
       </div>
 
-      <div className="hidden md:flex items-center gap-4">
+      <div className="hidden md:flex items-center gap-md">
         <a href="/cart" className="relative">
           <FaShoppingBag />
           {items.length > 0 && (
-            <span className="absolute -top-2 -right-2 bg-black text-white text-xs rounded-full px-1">{items.length}</span>
+            <span className="absolute -top-2 -right-2 bg-brand-primary text-white text-xs rounded-full px-1">{items.length}</span>
           )}
         </a>
         <a href="/login">

--- a/var/www/frontend-next/components/ProductGrid.tsx
+++ b/var/www/frontend-next/components/ProductGrid.tsx
@@ -25,13 +25,13 @@ export default function ProductGrid() {
   }, [])
 
   return (
-    <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6 py-8">
+    <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-lg py-xl">
       {products.map((p) => (
         <a key={p.id} href={`/product/${p.id}`} className="group block">
           <div className="overflow-hidden">
             <img src={p.thumbnail} className="object-cover w-full h-56 group-hover:scale-105 transition-transform" />
           </div>
-          <div className="mt-2 text-sm">
+          <div className="mt-xs text-sm">
             <h3>{p.title}</h3>
             <p className="font-semibold">${p.price.toFixed(2)}</p>
           </div>

--- a/var/www/frontend-next/tailwind.config.js
+++ b/var/www/frontend-next/tailwind.config.js
@@ -18,7 +18,19 @@ module.exports = {
           700: '#374151',
           800: '#1f2937',
           900: '#111827'
+        },
+        brand: {
+          primary: '#000',
+          secondary: '#4b5563'
         }
+      },
+      spacing: {
+        xs: '0.5rem',
+        sm: '0.75rem',
+        md: '1rem',
+        lg: '1.5rem',
+        xl: '2rem',
+        '2xl': '3rem'
       }
     }
   },


### PR DESCRIPTION
## Summary
- extend Tailwind with brand color and spacing tokens
- use brand tokens instead of hardcoded colors
- unify headings and body with grotesk/arabic fonts

## Testing
- `npm run lint`
- `npm run build` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_b_689460f9bf908321a6f8d7748ba9b971