### PR TITLE
refactor: use next/image for product and layout images

### DIFF
--- a/var/www/frontend-next/app/product/[id]/page.tsx
+++ b/var/www/frontend-next/app/product/[id]/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { useEffect, useState } from 'react'
+import Image from 'next/image'
 import { medusa } from '../../../lib/medusa'
 import { useCart } from '../../../lib/store'
 
@@ -38,7 +39,15 @@ export default function ProductPage({ params }: { params: { id: string } }) {
       <div className="flex flex-col md:flex-row gap-8">
         <div className="flex-1 space-y-4">
           {product.images.map((img, i) => (
-            <img key={i} src={img.url} alt={product.title} className="w-full object-cover" />
+            <div key={i} className="relative w-full aspect-square">
+              <Image
+                src={img.url}
+                alt={`${product.title} image ${i + 1}`}
+                fill
+                className="object-cover"
+                priority={i === 0}
+              />
+            </div>
           ))}
         </div>
         <div className="flex-1 space-y-4">

--- a/var/www/frontend-next/components/FeaturedProducts.tsx
+++ b/var/www/frontend-next/components/FeaturedProducts.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { useEffect, useState } from 'react'
+import Image from 'next/image'
 import { medusa } from '../lib/medusa'
 
 interface Product {
@@ -28,8 +29,13 @@ export default function FeaturedProducts() {
     <div className="grid grid-cols-2 md:grid-cols-4 gap-4 py-8">
       {products.map((p) => (
         <a key={p.id} href={`/product/${p.id}`} className="group block">
-          <div className="overflow-hidden">
-            <img src={p.thumbnail} className="object-cover w-full h-48 group-hover:scale-105 transition-transform" />
+          <div className="relative h-48 overflow-hidden">
+            <Image
+              src={p.thumbnail}
+              alt={p.title}
+              fill
+              className="object-cover group-hover:scale-105 transition-transform"
+            />
           </div>
           <div className="mt-2 text-sm">
             <h3>{p.title}</h3>

--- a/var/www/frontend-next/components/LookbookCarousel.tsx
+++ b/var/www/frontend-next/components/LookbookCarousel.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { useEffect, useState } from 'react'
+import Image from 'next/image'
 import { Swiper, SwiperSlide } from 'swiper/react'
 import 'swiper/css'
 import { sanity } from '../lib/sanity'
@@ -29,10 +30,16 @@ export default function LookbookCarousel() {
 
   return (
     <Swiper loop className="w-full h-[400px] md:h-[600px]">
-      {items.map((item) => (
+      {items.map((item, index) => (
         <SwiperSlide key={item.title}>
           <div className="relative w-full h-full">
-            <img src={item.url} alt={item.title} className="object-cover w-full h-full aspect-[3/4]" />
+            <Image
+              src={item.url}
+              alt={item.title}
+              fill
+              className="object-cover aspect-[3/4]"
+              priority={index === 0}
+            />
             <div className="absolute inset-0 bg-black/40 flex flex-col items-center justify-center text-white">
               <h2 className="text-2xl md:text-4xl font-bold mb-4 tracking-wider">
                 {item.season} Lookbook

--- a/var/www/frontend-next/components/Navbar.tsx
+++ b/var/www/frontend-next/components/Navbar.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { useState } from 'react'
+import Image from 'next/image'
 import { FaBars, FaTimes, FaShoppingBag, FaUser } from 'react-icons/fa'
 import { useCart } from '../lib/store'
 
@@ -10,7 +11,14 @@ export default function Navbar() {
   return (
     <nav className="sticky top-0 z-50 bg-white border-b border-gray-200 px-4 py-3 flex items-center justify-between">
       <a href="/" className="flex items-center">
-        <img src="/logo.png" alt="nabd.dhk logo" className="h-8 w-auto" />
+        <Image
+          src="/logo.png"
+          alt="nabd.dhk logo"
+          width={1749}
+          height={2481}
+          className="h-8 w-auto"
+          priority
+        />
       </a>
 
       <button className="md:hidden" onClick={() => setOpen(!open)}>

--- a/var/www/frontend-next/components/ProductGrid.tsx
+++ b/var/www/frontend-next/components/ProductGrid.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { useEffect, useState } from 'react'
+import Image from 'next/image'
 import { medusa } from '../lib/medusa'
 
 interface Product {
@@ -43,8 +44,13 @@ export default function ProductGrid({
     <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6 py-8">
       {products.map((p) => (
         <a key={p.id} href={`/product/${p.id}`} className="group block">
-          <div className="overflow-hidden">
-            <img src={p.thumbnail} className="object-cover w-full h-56 group-hover:scale-105 transition-transform" />
+          <div className="relative h-56 overflow-hidden">
+            <Image
+              src={p.thumbnail}
+              alt={p.title}
+              fill
+              className="object-cover group-hover:scale-105 transition-transform"
+            />
           </div>
           <div className="mt-2 text-sm">
             <h3>{p.title}</h3>


### PR DESCRIPTION
## Summary
- replace raw `<img>` elements with Next.js `Image`
- provide alt text, sizing, and priority for above-the-fold assets

## Testing
- `npm run lint`
- `npm run build` *(fails: ReactServerComponentsError, missing zustand middleware export)*

------
https://chatgpt.com/codex/tasks/task_b_689475bafca083219dfe28afa436413c