### PR TITLE
feat: add skeleton loading states

### DIFF
--- a/var/www/frontend-next/app/product/[id]/page.tsx
+++ b/var/www/frontend-next/app/product/[id]/page.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react'
 import Image from 'next/image'
 import { medusa } from '../../../lib/medusa'
 import { useCart } from '../../../lib/store'
+import ProductPageSkeleton from '../../../components/ProductPageSkeleton'
 
 interface Product {
   id: string
@@ -31,7 +32,7 @@ export default function ProductPage({ params }: { params: { id: string } }) {
   }, [id])
 
   if (!product) {
-    return <main className="p-8">Loading...</main>
+    return <ProductPageSkeleton />
   }
 
   return (

--- a/var/www/frontend-next/components/FeaturedProducts.tsx
+++ b/var/www/frontend-next/components/FeaturedProducts.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useState } from 'react'
 import Image from 'next/image'
 import { medusa } from '../lib/medusa'
+import ProductCardSkeleton from './ProductCardSkeleton'
 
 interface Product {
   id: string
@@ -12,37 +13,43 @@ interface Product {
 
 export default function FeaturedProducts() {
   const [products, setProducts] = useState<Product[]>([])
+  const [loading, setLoading] = useState(true)
 
   useEffect(() => {
-    medusa.products.list({ limit: 4 }).then(({ products }) => {
-      const mapped = products.map((p: any) => ({
-        id: p.id,
-        title: p.title,
-        thumbnail: p.thumbnail,
-        price: p.variants[0]?.prices[0]?.amount / 100 || 0
-      }))
-      setProducts(mapped)
-    })
+    medusa.products
+      .list({ limit: 4 })
+      .then(({ products }) => {
+        const mapped = products.map((p: any) => ({
+          id: p.id,
+          title: p.title,
+          thumbnail: p.thumbnail,
+          price: p.variants[0]?.prices[0]?.amount / 100 || 0
+        }))
+        setProducts(mapped)
+      })
+      .finally(() => setLoading(false))
   }, [])
 
   return (
     <div className="grid grid-cols-2 md:grid-cols-4 gap-4 py-8">
-      {products.map((p) => (
-        <a key={p.id} href={`/product/${p.id}`} className="group block">
-          <div className="relative h-48 overflow-hidden">
-            <Image
-              src={p.thumbnail}
-              alt={p.title}
-              fill
-              className="object-cover group-hover:scale-105 transition-transform"
-            />
-          </div>
-          <div className="mt-2 text-sm">
-            <h3>{p.title}</h3>
-            <p className="font-semibold">${p.price.toFixed(2)}</p>
-          </div>
-        </a>
-      ))}
+      {loading
+        ? Array.from({ length: 4 }).map((_, i) => <ProductCardSkeleton key={i} />)
+        : products.map((p) => (
+            <a key={p.id} href={`/product/${p.id}`} className="group block">
+              <div className="relative h-48 overflow-hidden">
+                <Image
+                  src={p.thumbnail}
+                  alt={p.title}
+                  fill
+                  className="object-cover group-hover:scale-105 transition-transform"
+                />
+              </div>
+              <div className="mt-2 text-sm">
+                <h3>{p.title}</h3>
+                <p className="font-semibold">${p.price.toFixed(2)}</p>
+              </div>
+            </a>
+          ))}
     </div>
   )
 }

--- a/var/www/frontend-next/components/LookbookCarousel.tsx
+++ b/var/www/frontend-next/components/LookbookCarousel.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image'
 import { Swiper, SwiperSlide } from 'swiper/react'
 import 'swiper/css'
 import { sanity } from '../lib/sanity'
+import LookbookSkeleton from './LookbookSkeleton'
 
 interface LookbookItem {
   title: string
@@ -13,19 +14,21 @@ interface LookbookItem {
 
 export default function LookbookCarousel() {
   const [items, setItems] = useState<LookbookItem[]>([])
+  const [loading, setLoading] = useState(true)
 
   useEffect(() => {
     sanity
       .fetch(
         `*[_type == "lookbookItem"]|order(order asc){title,season,"url":photo.asset->url}`
       )
-      .then(setItems)
+      .then((res) => {
+        setItems(res)
+        setLoading(false)
+      })
   }, [])
 
-  if (items.length === 0) {
-    return (
-      <div className="w-full h-[400px] md:h-[600px] bg-gray-200 flex items-center justify-center">Loading...</div>
-    )
+  if (loading) {
+    return <LookbookSkeleton />
   }
 
   return (

--- a/var/www/frontend-next/components/LookbookSkeleton.tsx
+++ b/var/www/frontend-next/components/LookbookSkeleton.tsx
@@ -1,0 +1,7 @@
+"use client"
+
+import Skeleton from './Skeleton'
+
+export default function LookbookSkeleton() {
+  return <Skeleton className="w-full h-[400px] md:h-[600px]" />
+}

--- a/var/www/frontend-next/components/ProductCardSkeleton.tsx
+++ b/var/www/frontend-next/components/ProductCardSkeleton.tsx
@@ -1,0 +1,15 @@
+"use client"
+
+import Skeleton from './Skeleton'
+
+export default function ProductCardSkeleton() {
+  return (
+    <div className="block">
+      <Skeleton className="h-56 w-full" />
+      <div className="mt-2 space-y-2">
+        <Skeleton className="h-4 w-3/4" />
+        <Skeleton className="h-4 w-1/2" />
+      </div>
+    </div>
+  )
+}

--- a/var/www/frontend-next/components/ProductGrid.tsx
+++ b/var/www/frontend-next/components/ProductGrid.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useState } from 'react'
 import Image from 'next/image'
 import { medusa } from '../lib/medusa'
+import ProductCardSkeleton from './ProductCardSkeleton'
 
 interface Product {
   id: string
@@ -22,6 +23,7 @@ export default function ProductGrid({
   search
 }: ProductGridProps) {
   const [products, setProducts] = useState<Product[]>([])
+  const [loading, setLoading] = useState(true)
 
   useEffect(() => {
     const params: any = {}
@@ -29,35 +31,40 @@ export default function ProductGrid({
     if (order) params.order = order
     if (search) params.q = search
 
-    medusa.products.list(params).then(({ products }) => {
-      const mapped = products.map((p: any) => ({
-        id: p.id,
-        title: p.title,
-        thumbnail: p.thumbnail,
-        price: p.variants[0]?.prices[0]?.amount / 100 || 0
-      }))
-      setProducts(mapped)
-    })
+    medusa.products
+      .list(params)
+      .then(({ products }) => {
+        const mapped = products.map((p: any) => ({
+          id: p.id,
+          title: p.title,
+          thumbnail: p.thumbnail,
+          price: p.variants[0]?.prices[0]?.amount / 100 || 0
+        }))
+        setProducts(mapped)
+      })
+      .finally(() => setLoading(false))
   }, [categoryId, order, search])
 
   return (
     <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6 py-8">
-      {products.map((p) => (
-        <a key={p.id} href={`/product/${p.id}`} className="group block">
-          <div className="relative h-56 overflow-hidden">
-            <Image
-              src={p.thumbnail}
-              alt={p.title}
-              fill
-              className="object-cover group-hover:scale-105 transition-transform"
-            />
-          </div>
-          <div className="mt-2 text-sm">
-            <h3>{p.title}</h3>
-            <p className="font-semibold">${p.price.toFixed(2)}</p>
-          </div>
-        </a>
-      ))}
+      {loading
+        ? Array.from({ length: 8 }).map((_, i) => <ProductCardSkeleton key={i} />)
+        : products.map((p) => (
+            <a key={p.id} href={`/product/${p.id}`} className="group block">
+              <div className="relative h-56 overflow-hidden">
+                <Image
+                  src={p.thumbnail}
+                  alt={p.title}
+                  fill
+                  className="object-cover group-hover:scale-105 transition-transform"
+                />
+              </div>
+              <div className="mt-2 text-sm">
+                <h3>{p.title}</h3>
+                <p className="font-semibold">${p.price.toFixed(2)}</p>
+              </div>
+            </a>
+          ))}
     </div>
   )
 }

--- a/var/www/frontend-next/components/ProductPageSkeleton.tsx
+++ b/var/www/frontend-next/components/ProductPageSkeleton.tsx
@@ -1,0 +1,26 @@
+"use client"
+
+import Skeleton from './Skeleton'
+
+export default function ProductPageSkeleton() {
+  return (
+    <main className="p-8">
+      <div className="flex flex-col md:flex-row gap-8">
+        <div className="flex-1 space-y-4">
+          <Skeleton className="w-full aspect-square" />
+          <Skeleton className="w-full aspect-square" />
+        </div>
+        <div className="flex-1 space-y-4">
+          <Skeleton className="h-8 w-1/2" />
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-3/4" />
+          <Skeleton className="h-6 w-1/3" />
+          <div className="flex gap-2">
+            <Skeleton className="h-10 w-20" />
+            <Skeleton className="h-10 w-32" />
+          </div>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/var/www/frontend-next/components/Skeleton.tsx
+++ b/var/www/frontend-next/components/Skeleton.tsx
@@ -1,0 +1,5 @@
+"use client"
+
+export default function Skeleton({ className = '' }: { className?: string }) {
+  return <div className={`animate-pulse bg-gray-700/50 rounded ${className}`} />
+}


### PR DESCRIPTION
## Summary
- add reusable skeleton components that use gray palette
- display skeletons in product lists, lookbook carousel, and product page while loading

## Testing
- `npm run lint`
- `npm run build` *(fails: ReactServerComponentsError and module not found in existing code)*

------
https://chatgpt.com/codex/tasks/task_b_6894780720a48321aa51d961d7d51035