### PR TITLE
feat: add form labels and validation

### DIFF
--- a/var/www/frontend-next/app/checkout/page.tsx
+++ b/var/www/frontend-next/app/checkout/page.tsx
@@ -1,16 +1,92 @@
+'use client';
+
+import { useState } from 'react';
+
 export default function CheckoutPage() {
+  const [form, setForm] = useState({ name: '', address: '', payment: '' });
+  const [errors, setErrors] = useState<{
+    name?: string;
+    address?: string;
+    payment?: string;
+  }>({});
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>,
+  ) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const newErrors: typeof errors = {};
+    if (!form.name) newErrors.name = 'Name is required';
+    if (!form.address) newErrors.address = 'Address is required';
+    if (!form.payment) newErrors.payment = 'Select a payment method';
+    setErrors(newErrors);
+    if (Object.keys(newErrors).length === 0) {
+      // handle order submission
+    }
+  };
+
   return (
     <main className="p-8 space-y-4">
       <h1 className="text-3xl font-bold mb-4 tracking-wider">Checkout</h1>
-      <form className="space-y-4 max-w-md">
-        <input type="text" placeholder="Name" className="w-full border p-2" />
-        <input type="text" placeholder="Address" className="w-full border p-2" />
-        <select className="w-full border p-2">
-          <option value="bkash">bKash</option>
-          <option value="cod">Cash on Delivery</option>
-        </select>
-        <button type="submit" className="w-full bg-black text-white py-2">Place order</button>
+      <form className="space-y-4 max-w-md" onSubmit={handleSubmit} noValidate>
+        <div>
+          <label htmlFor="checkout-name" className="block mb-1">
+            Name
+          </label>
+          <input
+            id="checkout-name"
+            name="name"
+            type="text"
+            value={form.name}
+            onChange={handleChange}
+            className={`w-full border p-2 ${
+              errors.name ? 'border-black' : 'border-gray-700'
+            }`}
+          />
+          {errors.name && <p className="text-gray-700">{errors.name}</p>}
+        </div>
+        <div>
+          <label htmlFor="checkout-address" className="block mb-1">
+            Address
+          </label>
+          <input
+            id="checkout-address"
+            name="address"
+            type="text"
+            value={form.address}
+            onChange={handleChange}
+            className={`w-full border p-2 ${
+              errors.address ? 'border-black' : 'border-gray-700'
+            }`}
+          />
+          {errors.address && <p className="text-gray-700">{errors.address}</p>}
+        </div>
+        <div>
+          <label htmlFor="checkout-payment" className="block mb-1">
+            Payment Method
+          </label>
+          <select
+            id="checkout-payment"
+            name="payment"
+            value={form.payment}
+            onChange={handleChange}
+            className={`w-full border p-2 ${
+              errors.payment ? 'border-black' : 'border-gray-700'
+            }`}
+          >
+            <option value="">Select</option>
+            <option value="bkash">bKash</option>
+            <option value="cod">Cash on Delivery</option>
+          </select>
+          {errors.payment && <p className="text-gray-700">{errors.payment}</p>}
+        </div>
+        <button type="submit" className="w-full bg-black text-white py-2">
+          Place order
+        </button>
       </form>
     </main>
-  )
+  );
 }

--- a/var/www/frontend-next/app/contact/page.tsx
+++ b/var/www/frontend-next/app/contact/page.tsx
@@ -1,15 +1,44 @@
-import { sanity } from '../../lib/sanity'
+'use client';
 
-export default async function ContactPage() {
-  const siteSettings =
-    (await sanity.fetch(
-      `*[_type == "siteSettings"][0]{contactEmail, instagramUrl}`
-    )) || {}
+import { useEffect, useState } from 'react';
+import { sanity } from '../../lib/sanity';
 
-  const { contactEmail, instagramUrl } = siteSettings as {
-    contactEmail?: string
-    instagramUrl?: string
-  }
+export default function ContactPage() {
+  const [form, setForm] = useState({ email: '', message: '' });
+  const [errors, setErrors] = useState<{ email?: string; message?: string }>(
+    {},
+  );
+  const [contactInfo, setContactInfo] = useState<{
+    contactEmail?: string;
+    instagramUrl?: string;
+  }>({});
+
+  useEffect(() => {
+    sanity
+      .fetch(`*[_type == "siteSettings"][0]{contactEmail, instagramUrl}`)
+      .then((data) => setContactInfo(data || {}));
+  }, []);
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const newErrors: typeof errors = {};
+    if (!form.email) newErrors.email = 'Email is required';
+    else if (!/^[\w.-]+@([\w-]+\.)+[\w-]{2,}$/.test(form.email))
+      newErrors.email = 'Enter a valid email';
+    if (!form.message) newErrors.message = 'Message is required';
+    setErrors(newErrors);
+    if (Object.keys(newErrors).length === 0) {
+      // handle submission
+    }
+  };
+
+  const { contactEmail, instagramUrl } = contactInfo;
 
   return (
     <main className="p-8 space-y-4">
@@ -39,11 +68,43 @@ export default async function ContactPage() {
           )}
         </p>
       </div>
-      <form className="space-y-4 max-w-md">
-        <input type="email" placeholder="Email" className="w-full border p-2" />
-        <textarea placeholder="Message" className="w-full border p-2" rows={4} />
-        <button className="bg-black text-white px-4 py-2" type="submit">Send</button>
+      <form className="space-y-4 max-w-md" onSubmit={handleSubmit} noValidate>
+        <div>
+          <label htmlFor="contact-email" className="block mb-1">
+            Email
+          </label>
+          <input
+            id="contact-email"
+            name="email"
+            type="email"
+            value={form.email}
+            onChange={handleChange}
+            className={`w-full border p-2 ${
+              errors.email ? 'border-black' : 'border-gray-700'
+            }`}
+          />
+          {errors.email && <p className="text-gray-700">{errors.email}</p>}
+        </div>
+        <div>
+          <label htmlFor="contact-message" className="block mb-1">
+            Message
+          </label>
+          <textarea
+            id="contact-message"
+            name="message"
+            value={form.message}
+            onChange={handleChange}
+            className={`w-full border p-2 ${
+              errors.message ? 'border-black' : 'border-gray-700'
+            }`}
+            rows={4}
+          />
+          {errors.message && <p className="text-gray-700">{errors.message}</p>}
+        </div>
+        <button className="bg-black text-white px-4 py-2" type="submit">
+          Send
+        </button>
       </form>
     </main>
-  )
+  );
 }


### PR DESCRIPTION
## Summary
- add labeled, validated contact form
- apply client-side validation to checkout form with error styling

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6894782419c88321af4c8c4cac86422f