### PR TITLE
fix: mark shop page as client component

### DIFF
--- a/var/www/frontend-next/app/shop/page.tsx
+++ b/var/www/frontend-next/app/shop/page.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { useEffect, useState } from 'react'
 import ProductGrid from '../../components/ProductGrid'
 import { medusa } from '../../lib/medusa'


### PR DESCRIPTION
## Summary
- mark shop page as client component so React hooks work

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68962ab9bb94832182bbd26f99f705b0