### PR TITLE
Improve navigation and image handling

### DIFF
--- a/var/www/frontend-next/app/product/[id]/page.tsx
+++ b/var/www/frontend-next/app/product/[id]/page.tsx
@@ -41,13 +41,18 @@ export default function ProductPage({ params }: { params: { id: string } }) {
         <div className="flex-1 space-y-4">
           {product.images.map((img, i) => (
             <div key={i} className="relative w-full aspect-square">
-              <Image
-                src={img.url}
-                alt={`${product.title} image ${i + 1}`}
-                fill
-                className="object-cover"
-                priority={i === 0}
-              />
+              {img.url ? (
+                <Image
+                  src={img.url}
+                  alt={`${product.title} image ${i + 1}`}
+                  fill
+                  sizes="(max-width:768px) 100vw, 50vw"
+                  className="object-cover"
+                  priority={i === 0}
+                />
+              ) : (
+                <div className="w-full h-full bg-gray-100" />
+              )}
             </div>
           ))}
         </div>

--- a/var/www/frontend-next/components/FeaturedProducts.tsx
+++ b/var/www/frontend-next/components/FeaturedProducts.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { useEffect, useState } from 'react'
 import Image from 'next/image'
+import Link from 'next/link'
 import { medusa } from '../lib/medusa'
 import ProductCardSkeleton from './ProductCardSkeleton'
 
@@ -35,20 +36,25 @@ export default function FeaturedProducts() {
       {loading
         ? Array.from({ length: 4 }).map((_, i) => <ProductCardSkeleton key={i} />)
         : products.map((p) => (
-            <a key={p.id} href={`/product/${p.id}`} className="group block">
+            <Link key={p.id} href={`/product/${p.id}`} className="group block">
               <div className="relative h-48 overflow-hidden">
-                <Image
-                  src={p.thumbnail}
-                  alt={p.title}
-                  fill
-                  className="object-cover group-hover:scale-105 transition-transform"
-                />
+                {p.thumbnail ? (
+                  <Image
+                    src={p.thumbnail}
+                    alt={p.title}
+                    fill
+                    sizes="(max-width:768px) 50vw, 25vw"
+                    className="object-cover group-hover:scale-105 transition-transform"
+                  />
+                ) : (
+                  <div className="w-full h-full bg-gray-100" />
+                )}
               </div>
               <div className="mt-2 text-sm">
                 <h3>{p.title}</h3>
                 <p className="font-semibold">${p.price.toFixed(2)}</p>
               </div>
-            </a>
+            </Link>
           ))}
     </div>
   )

--- a/var/www/frontend-next/components/Footer.tsx
+++ b/var/www/frontend-next/components/Footer.tsx
@@ -1,3 +1,5 @@
+import Link from 'next/link'
+
 export default function Footer() {
   return (
     <footer className="border-t border-gray-200 text-center text-sm p-8 space-y-4">
@@ -5,9 +7,9 @@ export default function Footer() {
         Drawing inspiration from contemporary global trends, we create timeless pieces with impeccable craftsmanship, proudly produced right here at home
       </p>
       <nav className="flex justify-center space-x-6 text-gray-600">
-        <a href="/story">About</a>
-        <a href="/terms">Terms & Conditions</a>
-        <a href="/privacy">Privacy Policy</a>
+        <Link href="/story">About</Link>
+        <Link href="/terms">Terms & Conditions</Link>
+        <Link href="/privacy">Privacy Policy</Link>
       </nav>
       <p>aiowardrobes@gmail.com</p>
       <p>Dhaka, Bangladesh</p>

--- a/var/www/frontend-next/components/LookbookCarousel.tsx
+++ b/var/www/frontend-next/components/LookbookCarousel.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { useEffect, useState } from 'react'
 import Image from 'next/image'
+import Link from 'next/link'
 import { Swiper, SwiperSlide } from 'swiper/react'
 import 'swiper/css'
 import { sanity } from '../lib/sanity'
@@ -36,18 +37,23 @@ export default function LookbookCarousel() {
       {items.map((item, index) => (
         <SwiperSlide key={item.title}>
           <div className="relative w-full h-full">
-            <Image
-              src={item.url}
-              alt={item.title}
-              fill
-              className="object-cover aspect-[3/4]"
-              priority={index === 0}
-            />
+            {item.url ? (
+              <Image
+                src={item.url}
+                alt={item.title}
+                fill
+                sizes="100vw"
+                className="object-cover aspect-[3/4]"
+                priority={index === 0}
+              />
+            ) : (
+              <div className="w-full h-full bg-gray-100" />
+            )}
             <div className="absolute inset-0 bg-black/40 flex flex-col items-center justify-center text-white">
               <h2 className="text-2xl md:text-4xl font-bold mb-4 tracking-wider">
                 {item.season} Lookbook
               </h2>
-              <a href="/shop" className="px-4 py-2 bg-white text-black font-semibold text-sm md:text-base">Shop now</a>
+              <Link href="/shop" className="px-4 py-2 bg-white text-black font-semibold text-sm md:text-base">Shop now</Link>
             </div>
           </div>
         </SwiperSlide>

--- a/var/www/frontend-next/components/Navbar.tsx
+++ b/var/www/frontend-next/components/Navbar.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { useState } from 'react'
 import Image from 'next/image'
+import Link from 'next/link'
 import { FaBars, FaTimes, FaShoppingBag, FaUser } from 'react-icons/fa'
 import { useCart } from '../lib/store'
 
@@ -10,7 +11,7 @@ export default function Navbar() {
 
   return (
     <nav className="sticky top-0 z-50 bg-white border-b border-gray-200 px-4 py-3 flex items-center justify-between">
-      <a href="/" className="flex items-center">
+      <Link href="/" className="flex items-center">
         <Image
           src="/logo.png"
           alt="nabd.dhk logo"
@@ -19,32 +20,32 @@ export default function Navbar() {
           className="h-8 w-auto"
           priority
         />
-      </a>
+      </Link>
 
       <button className="md:hidden" onClick={() => setOpen(!open)}>
         {open ? <FaTimes /> : <FaBars />}
       </button>
 
       <div className={`flex-col md:flex-row md:flex gap-6 ${open ? 'flex' : 'hidden'} md:items-center`}>
-        <a href="/">Home</a>
-        <a href="/shop">Shop</a>
-        <a href="/contact">Contact</a>
-        <a href="/story">Our Story</a>
-        <a href="/shop?category=MEN">MEN</a>
-        <a href="/shop?category=WOMEN">WOMEN</a>
-        <a href="/shop?category=UNISEX">UNISEX</a>
+        <Link href="/">Home</Link>
+        <Link href="/shop">Shop</Link>
+        <Link href="/contact">Contact</Link>
+        <Link href="/story">Our Story</Link>
+        <Link href="/shop?category=MEN">MEN</Link>
+        <Link href="/shop?category=WOMEN">WOMEN</Link>
+        <Link href="/shop?category=UNISEX">UNISEX</Link>
       </div>
 
       <div className="hidden md:flex items-center gap-4">
-        <a href="/cart" className="relative">
+        <Link href="/cart" className="relative">
           <FaShoppingBag />
           {itemCount > 0 && (
             <span className="absolute -top-2 -right-2 bg-black text-white text-xs rounded-full px-1">{itemCount}</span>
           )}
-        </a>
-        <a href="/login">
+        </Link>
+        <Link href="/login">
           <FaUser />
-        </a>
+        </Link>
       </div>
     </nav>
   )

--- a/var/www/frontend-next/components/ProductGrid.tsx
+++ b/var/www/frontend-next/components/ProductGrid.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { useEffect, useState } from 'react'
 import Image from 'next/image'
+import Link from 'next/link'
 import { medusa } from '../lib/medusa'
 import ProductCardSkeleton from './ProductCardSkeleton'
 
@@ -26,6 +27,7 @@ export default function ProductGrid({
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
+    setLoading(true)
     const params: any = {}
     if (categoryId) params.category_id = categoryId
     if (order) params.order = order
@@ -50,20 +52,25 @@ export default function ProductGrid({
       {loading
         ? Array.from({ length: 8 }).map((_, i) => <ProductCardSkeleton key={i} />)
         : products.map((p) => (
-            <a key={p.id} href={`/product/${p.id}`} className="group block">
+            <Link key={p.id} href={`/product/${p.id}`} className="group block">
               <div className="relative h-56 overflow-hidden">
-                <Image
-                  src={p.thumbnail}
-                  alt={p.title}
-                  fill
-                  className="object-cover group-hover:scale-105 transition-transform"
-                />
+                {p.thumbnail ? (
+                  <Image
+                    src={p.thumbnail}
+                    alt={p.title}
+                    fill
+                    sizes="(max-width:768px) 50vw, (max-width:1024px) 33vw, 25vw"
+                    className="object-cover group-hover:scale-105 transition-transform"
+                  />
+                ) : (
+                  <div className="w-full h-full bg-gray-100" />
+                )}
               </div>
               <div className="mt-2 text-sm">
                 <h3>{p.title}</h3>
                 <p className="font-semibold">${p.price.toFixed(2)}</p>
               </div>
-            </a>
+            </Link>
           ))}
     </div>
   )

--- a/var/www/frontend-next/next.config.js
+++ b/var/www/frontend-next/next.config.js
@@ -3,7 +3,22 @@ const nextConfig = {
   experimental: {
     appDir: true
   },
-  output: 'standalone'
+  output: 'standalone',
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'http',
+        hostname: 'localhost',
+        port: '7001',
+        pathname: '/**'
+      },
+      {
+        protocol: 'https',
+        hostname: 'cdn.sanity.io',
+        pathname: '/**'
+      }
+    ]
+  }
 }
 
 module.exports = nextConfig

--- a/var/www/frontend-next/tsconfig.json
+++ b/var/www/frontend-next/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": false,
@@ -13,8 +17,20 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary
- Reset product grid loading when filters change
- Guard images, add responsive sizes, and use Next.js `Link` for internal navigation
- Whitelist Medusa and Sanity image hosts in Next.js config

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68963117282c8321bab75c0dfae4451b