### PR TITLE
Improve navbar with search and cart icons

### DIFF
--- a/var/www/frontend-next/app/search/page.tsx
+++ b/var/www/frontend-next/app/search/page.tsx
@@ -1,0 +1,37 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import { useRouter, useSearchParams } from "next/navigation"
+import ProductGrid from "../../components/ProductGrid"
+
+export default function SearchPage() {
+  const searchParams = useSearchParams()
+  const router = useRouter()
+  const q = searchParams.get("q") || ""
+  const [query, setQuery] = useState(q)
+
+  useEffect(() => {
+    setQuery(q)
+  }, [q])
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    router.push(`/search?q=${encodeURIComponent(query)}`)
+  }
+
+  return (
+    <main className="p-8">
+      <h1 className="text-3xl font-bold mb-4 tracking-wider">Search</h1>
+      <form onSubmit={handleSubmit} className="mb-6">
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search products..."
+          className="border p-2 rounded w-full"
+        />
+      </form>
+      <ProductGrid q={q || undefined} />
+    </main>
+  )
+}

--- a/var/www/frontend-next/components/Navbar.tsx
+++ b/var/www/frontend-next/components/Navbar.tsx
@@ -1,14 +1,20 @@
 "use client"
 import Image from "next/image"
 import Link from "next/link"
-import { FaBars } from "react-icons/fa"
+import { FaBars, FaShoppingCart, FaSearch } from "react-icons/fa"
 
 export default function Navbar() {
   return (
     <nav className="sticky top-0 z-50 bg-white border-b border-gray-200 grid grid-cols-3 items-center h-16 px-4">
-      <button className="justify-self-start">
-        <FaBars />
-      </button>
+      <div className="flex items-center gap-6">
+        <button className="md:hidden">
+          <FaBars />
+        </button>
+        <div className="hidden md:flex items-center gap-6">
+          <Link href="/">Home</Link>
+          <Link href="/shop">Shop</Link>
+        </div>
+      </div>
       <div className="justify-self-center">
         <Link href="/">
           <div className="relative h-12 w-28 overflow-hidden">
@@ -24,9 +30,12 @@ export default function Navbar() {
         </Link>
       </div>
       <div className="justify-self-end flex items-center gap-6">
-        <Link href="/shop">Shop</Link>
-        <Link href="/search">Search</Link>
-        <Link href="/">Home</Link>
+        <Link href="/search" aria-label="Search">
+          <FaSearch />
+        </Link>
+        <Link href="/cart" aria-label="Cart">
+          <FaShoppingCart />
+        </Link>
       </div>
     </nav>
   )


### PR DESCRIPTION
## Summary
- Replace text links with search and cart icons in the navbar
- Hide mobile menu icon on desktop and move Home/Shop links to left
- Add search page with query handling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68993134fe0483219526643c8395b19d