### PR TITLE
chore: remove unused dependencies

### DIFF
--- a/var/www/frontend-next/package-lock.json
+++ b/var/www/frontend-next/package-lock.json
@@ -23,7 +23,6 @@
         "eslint": "^8.53.0",
         "eslint-config-next": "14.0.0",
         "postcss": "^8.4.31",
-        "prettier": "^2.8.8",
         "tailwindcss": "^3.3.5",
         "typescript": "^5.2.2"
       }
@@ -9426,22 +9425,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin-prettier.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/process": {

--- a/var/www/frontend-next/package.json
+++ b/var/www/frontend-next/package.json
@@ -24,7 +24,6 @@
     "eslint": "^8.53.0",
     "eslint-config-next": "14.0.0",
     "postcss": "^8.4.31",
-    "prettier": "^2.8.8",
     "tailwindcss": "^3.3.5",
     "typescript": "^5.2.2"
   }

--- a/var/www/medusa-backend/package-lock.json
+++ b/var/www/medusa-backend/package-lock.json
@@ -7,9 +7,8 @@
       "name": "medusa-backend",
       "dependencies": {
         "@medusajs/admin": "^7.1.18",
-        "@medusajs/cache-inmemory": "^1.8.1",
-        "@medusajs/event-bus-local": "^1.8.0",
         "@medusajs/medusa": "^1.7.8",
+        "dotenv": "^17.2.1",
         "medusa-file-local": "^2.0.9",
         "medusa-fulfillment-manual": "^1.1.41",
         "medusa-payment-manual": "^1.0.25",
@@ -3799,6 +3798,18 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/@medusajs/admin/node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/@medusajs/admin/node_modules/encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -3969,18 +3980,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/@medusajs/cache-inmemory": {
-      "version": "1.8.11",
-      "resolved": "https://registry.npmjs.org/@medusajs/cache-inmemory/-/cache-inmemory-1.8.11.tgz",
-      "integrity": "sha512-D+K+1izti1qJoS2l8mkKQTI306rXM0OJSq8FNxjxp1rXekoBPGX5hz7es+C9M76H5+PShnhlqIlTfL1qkCRsgw==",
-      "license": "MIT",
-      "dependencies": {
-        "@medusajs/modules-sdk": "^1.12.12"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
     "node_modules/@medusajs/core-flows": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/@medusajs/core-flows/-/core-flows-0.0.10.tgz",
@@ -3992,20 +3991,6 @@
         "@medusajs/utils": "^1.11.10",
         "@medusajs/workflows-sdk": "^0.1.8",
         "awilix": "^8.0.1",
-        "ulid": "^2.3.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@medusajs/event-bus-local": {
-      "version": "1.9.9",
-      "resolved": "https://registry.npmjs.org/@medusajs/event-bus-local/-/event-bus-local-1.9.9.tgz",
-      "integrity": "sha512-4KC6kpGjoqooLIUFftTxd/pxQ3f8jTqTZugSXkTr3ptyvlmeGxKkORQowv8izo2GgUL8/00DNg4lW7YmizLxkw==",
-      "license": "MIT",
-      "dependencies": {
-        "@medusajs/modules-sdk": "^1.12.12",
-        "@medusajs/utils": "^1.11.10",
         "ulid": "^2.3.0"
       },
       "engines": {
@@ -4149,6 +4134,18 @@
         "node": ">=16"
       }
     },
+    "node_modules/@medusajs/medusa-cli/node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/@medusajs/medusa-js": {
       "version": "6.1.10",
       "resolved": "https://registry.npmjs.org/@medusajs/medusa-js/-/medusa-js-6.1.10.tgz",
@@ -4175,6 +4172,18 @@
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.14.4"
+      }
+    },
+    "node_modules/@medusajs/medusa/node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/@medusajs/modules-sdk": {
@@ -13315,9 +13324,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "version": "17.2.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
+      "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -21491,6 +21500,18 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/typeorm/node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/typeorm/node_modules/glob": {

--- a/var/www/medusa-backend/package.json
+++ b/var/www/medusa-backend/package.json
@@ -8,9 +8,8 @@
   },
   "dependencies": {
     "@medusajs/admin": "^7.1.18",
-    "@medusajs/cache-inmemory": "^1.8.1",
-    "@medusajs/event-bus-local": "^1.8.0",
     "@medusajs/medusa": "^1.7.8",
+    "dotenv": "^17.2.1",
     "medusa-file-local": "^2.0.9",
     "medusa-fulfillment-manual": "^1.1.41",
     "medusa-payment-manual": "^1.0.25",


### PR DESCRIPTION
## Summary
- remove prettier from frontend dev dependencies
- drop unused medusa backend packages and include dotenv

## Testing
- `npx depcheck` in `var/www/frontend-next`
- `npx depcheck` in `var/www/medusa-backend`
- `npm test` in `var/www/frontend-next`
- `npm test` in `var/www/medusa-backend`


------
https://chatgpt.com/codex/tasks/task_b_68999a96dd1c8321bd12fe95c0c07730