### PR TITLE
feat: enhance navigation and mobile menu

### DIFF
--- a/var/www/frontend-next/components/MobileMenu.tsx
+++ b/var/www/frontend-next/components/MobileMenu.tsx
@@ -1,0 +1,42 @@
+"use client"
+import Link from "next/link"
+import { FaTimes } from "react-icons/fa"
+
+interface Props {
+  open: boolean
+  onClose: () => void
+}
+
+export default function MobileMenu({ open, onClose }: Props) {
+  return (
+    <>
+      <div
+        className={`fixed inset-0 bg-black transition-opacity duration-300 ${
+          open ? "bg-opacity-50" : "bg-opacity-0 pointer-events-none"
+        }`}
+        onClick={onClose}
+      />
+      <aside
+        className={`fixed left-0 top-0 w-64 h-full bg-white shadow-lg p-4 transform transition-transform duration-300 ${
+          open ? "translate-x-0" : "-translate-x-full"
+        }`}
+      >
+        <button
+          className="absolute top-4 right-4 hover:text-white hover:bg-black p-1 rounded"
+          onClick={onClose}
+          aria-label="Close menu"
+        >
+          <FaTimes />
+        </button>
+        <nav className="mt-8 flex flex-col space-y-4">
+          <Link href="/" className="hover:underline decoration-gray-300" onClick={onClose}>
+            Home
+          </Link>
+          <Link href="/shop" className="hover:underline decoration-gray-300" onClick={onClose}>
+            Shop
+          </Link>
+        </nav>
+      </aside>
+    </>
+  )
+}

--- a/var/www/frontend-next/components/Navbar.tsx
+++ b/var/www/frontend-next/components/Navbar.tsx
@@ -1,42 +1,58 @@
 "use client"
+import { useState } from "react"
 import Image from "next/image"
 import Link from "next/link"
+import dynamic from "next/dynamic"
 import { FaBars, FaShoppingCart, FaSearch } from "react-icons/fa"
+import { useCart } from "../lib/store"
+
+const MobileMenu = dynamic(() => import("./MobileMenu"), { ssr: false })
 
 export default function Navbar() {
+  const cartQuantity = useCart((state) => state.totalItems())
+  const [menuOpen, setMenuOpen] = useState(false)
+
   return (
-    <nav className="sticky top-0 z-50 bg-white border-b border-gray-200 grid grid-cols-3 items-center h-16 px-4">
-      <div className="flex items-center gap-6">
-        <button className="md:hidden">
-          <FaBars />
-        </button>
-        <div className="hidden md:flex items-center gap-6">
-          <Link href="/">Home</Link>
-          <Link href="/shop">Shop</Link>
-        </div>
-      </div>
-      <div className="justify-self-center">
-        <Link href="/">
-          <div className="relative h-12 w-28 overflow-hidden">
-            <Image
-              src="/logo.svg"
-              alt="nabd.dhk logo"
-              fill
-              className="object-cover"
-              priority
-              sizes="7rem"
-            />
+    <header className="sticky top-0 z-50 bg-white border-b border-gray-200">
+      <nav className="grid grid-cols-3 items-center h-16 px-4">
+        <div className="flex items-center gap-6">
+          <button className="md:hidden hover:text-white hover:bg-black p-1 rounded" onClick={() => setMenuOpen(true)}>
+            <FaBars />
+          </button>
+          <div className="hidden md:flex items-center gap-6">
+            <Link href="/" className="hover:underline decoration-gray-300">Home</Link>
+            <Link href="/shop" className="hover:underline decoration-gray-300">Shop</Link>
           </div>
-        </Link>
-      </div>
-      <div className="justify-self-end flex items-center gap-6">
-        <Link href="/search" aria-label="Search">
-          <FaSearch />
-        </Link>
-        <Link href="/cart" aria-label="Cart">
-          <FaShoppingCart />
-        </Link>
-      </div>
-    </nav>
+        </div>
+        <div className="justify-self-center">
+          <Link href="/">
+            <div className="relative h-12 w-28 overflow-hidden">
+              <Image
+                src="/logo.svg"
+                alt="nabd.dhk logo"
+                fill
+                className="object-cover"
+                priority
+                sizes="7rem"
+              />
+            </div>
+          </Link>
+        </div>
+        <div className="justify-self-end flex items-center gap-6">
+          <Link href="/search" aria-label="Search" className="hover:text-white hover:bg-black p-1 rounded">
+            <FaSearch />
+          </Link>
+          <Link href="/cart" aria-label="Cart" className="relative hover:text-white hover:bg-black p-1 rounded">
+            <FaShoppingCart />
+            {cartQuantity > 0 && (
+              <span className="absolute -top-2 -right-2 bg-red-500 text-white rounded-full text-xs w-4 h-4 flex items-center justify-center">
+                {cartQuantity}
+              </span>
+            )}
+          </Link>
+        </div>
+      </nav>
+      {menuOpen && <MobileMenu open={menuOpen} onClose={() => setMenuOpen(false)} />}
+    </header>
   )
 }


### PR DESCRIPTION
## Summary
- show cart quantity with Zustand badge
- wrap nav in sticky header with hover effects
- load mobile slide-over menu dynamically

## Testing
- `npm run lint`
- `npm run build` *(fails: TypeError: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_b_689a750347d08321a00a88737f26ce76