### PR TITLE
Use Lookbook carousel as responsive hero

### DIFF
--- a/var/www/frontend-next/app/page.tsx
+++ b/var/www/frontend-next/app/page.tsx
@@ -1,22 +1,9 @@
 import LookbookCarousel from '../components/LookbookCarousel'
 import FeaturedProducts from '../components/FeaturedProducts'
-import { sanity } from '../lib/sanity'
 
-export default async function HomePage() {
-  const siteSettings =
-    (await sanity.fetch(
-      `*[_type == "siteSettings"][0]{heroTagline}`
-    )) || {}
-
-  const heroTagline = siteSettings.heroTagline || ''
-
+export default function HomePage() {
   return (
     <main>
-      {heroTagline && (
-        <section className="py-12 text-center bg-gray-100">
-          <h1 className="text-3xl font-bold tracking-wider">{heroTagline}</h1>
-        </section>
-      )}
       <LookbookCarousel />
       <section className="container mx-auto px-4">
         <h2 className="text-2xl font-bold mt-8 mb-4 tracking-wider">Featured products</h2>

--- a/var/www/frontend-next/components/LookbookCarousel.tsx
+++ b/var/www/frontend-next/components/LookbookCarousel.tsx
@@ -38,7 +38,7 @@ export default function LookbookCarousel() {
   }
 
   return (
-    <Swiper loop className="w-full h-[400px] md:h-[600px]">
+    <Swiper loop className="w-full h-[60vh] md:h-[80vh]">
       {items.map((item, index) => (
         <SwiperSlide key={item.title}>
           <div className="relative w-full h-full hero-zoom">
@@ -47,7 +47,7 @@ export default function LookbookCarousel() {
               alt={item.title}
               fill
               sizes="100vw"
-              className="object-cover aspect-[3/4]"
+              className="object-cover"
               priority={index === 0}
             />
             <div className="absolute inset-0 bg-black/40 flex flex-col items-center justify-center text-white">

--- a/var/www/frontend-next/components/LookbookSkeleton.tsx
+++ b/var/www/frontend-next/components/LookbookSkeleton.tsx
@@ -3,5 +3,5 @@
 import Skeleton from './Skeleton'
 
 export default function LookbookSkeleton() {
-  return <Skeleton className="w-full h-[400px] md:h-[600px]" />
+  return <Skeleton className="w-full h-[60vh] md:h-[80vh]" />
 }


### PR DESCRIPTION
## Summary
- Remove old tagline hero and make the Lookbook carousel the landing hero.
- Size the carousel to 60vh on small screens and 80vh on desktop for a dramatic hero effect.
- Match skeleton loader to the carousel's viewport-based sizing.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689a82a8a18c8321926cc7613e01554d