### PR TITLE
refactor: lazy load carousel and server-side product grid

### DIFF
--- a/var/www/frontend-next/app/shop/page.tsx
+++ b/var/www/frontend-next/app/shop/page.tsx
@@ -1,9 +1,18 @@
 "use client"
 
-import { useState } from "react"
+import { useState, Suspense } from "react"
+import dynamic from "next/dynamic"
 import ProductGrid from "../../components/ProductGrid"
-import CollectionsDropdown from "../../components/CollectionsDropdown"
-import CategoriesDropdown from "../../components/CategoriesDropdown"
+import ProductCardSkeleton from "../../components/ProductCardSkeleton"
+
+const CollectionsDropdown = dynamic(
+  () => import("../../components/CollectionsDropdown"),
+  { ssr: false }
+)
+const CategoriesDropdown = dynamic(
+  () => import("../../components/CategoriesDropdown"),
+  { ssr: false }
+)
 
 export default function ShopPage() {
   const [collection, setCollection] = useState("")
@@ -38,12 +47,22 @@ export default function ShopPage() {
         />
       </div>
 
-      <ProductGrid
-        collectionId={collection || undefined}
-        categoryId={category || undefined}
-        order={order || undefined}
-        q={q || undefined}
-      />
+      <Suspense
+        fallback={
+          <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6 py-8">
+            {Array.from({ length: 8 }).map((_, i) => (
+              <ProductCardSkeleton key={i} />
+            ))}
+          </div>
+        }
+      >
+        <ProductGrid
+          collectionId={collection || undefined}
+          categoryId={category || undefined}
+          order={order || undefined}
+          q={q || undefined}
+        />
+      </Suspense>
     </main>
   )
 }

--- a/var/www/frontend-next/components/LookbookCarousel.tsx
+++ b/var/www/frontend-next/components/LookbookCarousel.tsx
@@ -1,11 +1,18 @@
-'use client'
-import { useEffect, useState } from 'react'
+import dynamic from 'next/dynamic'
 import Image from 'next/image'
 import Link from 'next/link'
-import { Swiper, SwiperSlide } from 'swiper/react'
 import 'swiper/css'
 import { sanity } from '../lib/sanity'
 import LookbookSkeleton from './LookbookSkeleton'
+
+const Swiper = dynamic(
+  () => import('swiper/react').then((m) => m.Swiper),
+  { ssr: false, loading: () => <LookbookSkeleton /> }
+)
+const SwiperSlide = dynamic(
+  () => import('swiper/react').then((m) => m.SwiperSlide),
+  { ssr: false }
+)
 
 interface LookbookItem {
   title: string
@@ -13,29 +20,15 @@ interface LookbookItem {
   url: string
 }
 
-export default function LookbookCarousel() {
-  const [items, setItems] = useState<LookbookItem[]>([])
-  const [loading, setLoading] = useState(true)
-
-  useEffect(() => {
-    sanity
-      .fetch(
-        `*[_type == "lookbookItem"]|order(order asc){title,season,"url":photo.asset->url}`
-      )
-      .then((res) => {
-        const mapped = res.map((r: any) => ({
-          title: r.title,
-          season: r.season,
-          url: r.url || '/placeholder.svg'
-        }))
-        setItems(mapped)
-        setLoading(false)
-      })
-  }, [])
-
-  if (loading) {
-    return <LookbookSkeleton />
-  }
+export default async function LookbookCarousel() {
+  const res: any[] = await sanity.fetch(
+    `*[_type == "lookbookItem"]|order(order asc){title,season,"url":photo.asset->url}`
+  )
+  const items: LookbookItem[] = res.map((r: any) => ({
+    title: r.title,
+    season: r.season,
+    url: r.url || '/placeholder.svg'
+  }))
 
   return (
     <Swiper loop className="w-full h-[60vh] md:h-[80vh]">

--- a/var/www/frontend-next/components/ProductGrid.tsx
+++ b/var/www/frontend-next/components/ProductGrid.tsx
@@ -1,9 +1,6 @@
-'use client'
-import { useEffect, useState } from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
 import { medusa } from '../lib/medusa'
-import ProductCardSkeleton from './ProductCardSkeleton'
 
 interface Product {
   id: string
@@ -21,7 +18,7 @@ interface ProductGridProps {
   offset?: number
 }
 
-export default function ProductGrid({
+export default async function ProductGrid({
   collectionId,
   categoryId,
   q,
@@ -29,64 +26,45 @@ export default function ProductGrid({
   limit,
   offset
 }: ProductGridProps) {
-  const [products, setProducts] = useState<Product[]>([])
-  const [loading, setLoading] = useState(true)
+  const params: any = { limit, offset }
+  if (collectionId) params.collection_id = collectionId
+  if (categoryId) params.category_id = categoryId
+  if (q) params.q = q
+  if (order) params.order = order
 
-  useEffect(() => {
-    let cancelled = false
-    setLoading(true)
-    const params: any = { limit, offset }
-    if (collectionId) params.collection_id = collectionId
-    if (categoryId) params.category_id = categoryId
-    if (q) params.q = q
-    if (order) params.order = order
-
-    medusa.products
-      .list(params)
-      .then(({ products }) => {
-        if (cancelled) return
-        const mapped = products.map((p: any) => {
-          const thumb =
-            (typeof p.thumbnail === 'string' && p.thumbnail) ||
-            p.images?.[0]?.url ||
-            '/placeholder.svg'
-          return {
-            id: p.id,
-            title: p.title,
-            thumbnail: thumb,
-            price: p.variants[0]?.prices[0]?.amount / 100 || 0
-          }
-        })
-        setProducts(mapped)
-      })
-      .finally(() => !cancelled && setLoading(false))
-
-    return () => {
-      cancelled = true
+  const { products } = await medusa.products.list(params)
+  const mapped: Product[] = products.map((p: any) => {
+    const thumb =
+      (typeof p.thumbnail === 'string' && p.thumbnail) ||
+      p.images?.[0]?.url ||
+      '/placeholder.svg'
+    return {
+      id: p.id,
+      title: p.title,
+      thumbnail: thumb,
+      price: p.variants[0]?.prices[0]?.amount / 100 || 0
     }
-  }, [collectionId, categoryId, q, order, limit, offset])
+  })
 
   return (
     <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6 py-8">
-      {loading
-        ? Array.from({ length: 8 }).map((_, i) => <ProductCardSkeleton key={i} />)
-        : products.map((p) => (
-            <Link key={p.id} href={`/product/${p.id}`} className="group block">
-              <div className="relative h-56 overflow-hidden">
-                <Image
-                  src={p.thumbnail}
-                  alt={p.title}
-                  fill
-                  sizes="(max-width:768px) 50vw, (max-width:1024px) 33vw, 25vw"
-                  className="object-cover group-hover:scale-105 transition-transform"
-                />
-              </div>
-              <div className="mt-2 text-sm">
-                <h3>{p.title}</h3>
-                <p className="font-semibold">${p.price.toFixed(2)}</p>
-              </div>
-            </Link>
-          ))}
+      {mapped.map((p) => (
+        <Link key={p.id} href={`/product/${p.id}`} className="group block">
+          <div className="relative h-56 overflow-hidden">
+            <Image
+              src={p.thumbnail}
+              alt={p.title}
+              fill
+              sizes="(max-width:768px) 50vw, (max-width:1024px) 33vw, 25vw"
+              className="object-cover group-hover:scale-105 transition-transform"
+            />
+          </div>
+          <div className="mt-2 text-sm">
+            <h3>{p.title}</h3>
+            <p className="font-semibold">${p.price.toFixed(2)}</p>
+          </div>
+        </Link>
+      ))}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- load Swiper dynamically and fetch lookbook data on the server
- move product grid fetching to server component and wrap with Suspense
- dynamically import filter dropdowns for lighter initial bundle

## Testing
- `npx depcheck` *(frontend-next)*
- `npm run lint`
- `npm run build` *(fails: connect ECONNREFUSED / ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_b_689a851090dc8321a7ee88a9dda9a129