### PR TITLE
fix: display lookbook carousel hero

### DIFF
--- a/var/www/frontend-next/app/globals.css
+++ b/var/www/frontend-next/app/globals.css
@@ -1,3 +1,4 @@
+@import 'swiper/css';
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/var/www/frontend-next/components/LookbookCarouselClient.tsx
+++ b/var/www/frontend-next/components/LookbookCarouselClient.tsx
@@ -3,7 +3,6 @@
 import dynamic from 'next/dynamic'
 import Image from 'next/image'
 import Link from 'next/link'
-import 'swiper/css'
 import LookbookSkeleton from './LookbookSkeleton'
 
 const Swiper = dynamic(


### PR DESCRIPTION
## Summary
- load Swiper styles globally for the home lookbook carousel
- rely on global styles instead of component-level import to avoid white hero space

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_689b33719cd8832192cf23248e749d93