### PR TITLE
fix: guard Swiper loop when slides are insufficient

### DIFF
--- a/var/www/frontend-next/components/LookbookCarouselClient.tsx
+++ b/var/www/frontend-next/components/LookbookCarouselClient.tsx
@@ -21,10 +21,17 @@ interface LookbookItem {
 }
 
 export default function LookbookCarouselClient({ items }: { items: LookbookItem[] }) {
+  const slides = items.length === 1 ? [...items, items[0]] : items
+  const shouldLoop = slides.length > 1
+
   return (
-    <Swiper loop className="w-full h-[60vh] md:h-[80vh]">
-      {items.map((item, index) => (
-        <SwiperSlide key={item.title}>
+    <Swiper
+      loop={shouldLoop}
+      watchOverflow
+      className="w-full h-[60vh] md:h-[80vh]"
+    >
+      {slides.map((item, index) => (
+        <SwiperSlide key={`${item.title}-${index}`}>
           <div className="relative w-full h-full hero-zoom">
             <Image
               src={item.url}


### PR DESCRIPTION
## Summary
- prevent Swiper loop warning by duplicating single slides and gating loop
- auto-disable carousel when slides are fewer than `slidesPerView`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_689b3d607dfc83219bdad9d59a31333d