### PR TITLE
Add in-memory cache module for Medusa backend

### DIFF
--- a/var/www/medusa-backend/medusa-config.js
+++ b/var/www/medusa-backend/medusa-config.js
@@ -16,6 +16,7 @@ module.exports = {
     'medusa-fulfillment-manual',
     './admin-extensions',
     '@medusajs/event-bus-local',
+    '@medusajs/cache-inmemory',
     {
       resolve: 'medusa-file-local',
       options: {

--- a/var/www/medusa-backend/package-lock.json
+++ b/var/www/medusa-backend/package-lock.json
@@ -7,6 +7,7 @@
       "name": "medusa-backend",
       "dependencies": {
         "@medusajs/admin": "^7.1.18",
+        "@medusajs/cache-inmemory": "^1.8.0",
         "@medusajs/event-bus-local": "^1.8.0",
         "@medusajs/medusa": "^1.7.8",
         "dotenv": "^17.2.1",
@@ -3979,6 +3980,106 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/@medusajs/cache-inmemory": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@medusajs/cache-inmemory/-/cache-inmemory-1.8.0.tgz",
+      "integrity": "sha512-Tl/n/eA7zS2S5iDrP/MZvOn62hLObxYTSdgyMryokND3kLU1kBPCe85q9YrlmD1koqfBxCUGxn+174rNqwOhgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@medusajs/modules-sdk": "1.8.0"
+      }
+    },
+    "node_modules/@medusajs/cache-inmemory/node_modules/@medusajs/modules-sdk": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@medusajs/modules-sdk/-/modules-sdk-1.8.0.tgz",
+      "integrity": "sha512-zgjpcV4pEqc34Ad1cZMQxJCxRl9G1dfg/3xJZ4Z29IW5tO7jwFyzcN5Q8K8JMDW52BYNzunakf+QMzvHOM6GOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@medusajs/types": "1.8.0",
+        "@medusajs/utils": "1.8.0",
+        "awilix": "^8.0.0",
+        "glob": "7.1.6",
+        "medusa-telemetry": "^0.0.16",
+        "resolve-cwd": "^3.0.0"
+      }
+    },
+    "node_modules/@medusajs/cache-inmemory/node_modules/@medusajs/types": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@medusajs/types/-/types-1.8.0.tgz",
+      "integrity": "sha512-gShiDq7T44ATXaOYe9Ach7LIO+bnW6UuV46KL6Jk0Gk2P15wJ4/PY1aoYuySIfsyjQufXBFIyhw0gvJybrvB1A==",
+      "license": "MIT"
+    },
+    "node_modules/@medusajs/cache-inmemory/node_modules/@medusajs/utils": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@medusajs/utils/-/utils-1.8.0.tgz",
+      "integrity": "sha512-MLsxjRH6dXmvUVNykjIJKUUXU4apJ5DVpAgOcOowiRljghx9k/VgFdP0MjeKjc/baPqC6r5x4auiwZfx3Orb+A==",
+      "license": "MIT",
+      "dependencies": {
+        "awilix": "^8.0.0",
+        "class-transformer": "^0.5.1",
+        "class-validator": "^0.13.2",
+        "typeorm": "^0.3.11",
+        "ulid": "^2.3.0"
+      }
+    },
+    "node_modules/@medusajs/cache-inmemory/node_modules/class-validator": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.13.2.tgz",
+      "integrity": "sha512-yBUcQy07FPlGzUjoLuUfIOXzgynnQPPruyK1Ge2B74k9ROwnle1E+NxLWnUv5OLU8hA/qL5leAE9XnXq3byaBw==",
+      "license": "MIT",
+      "dependencies": {
+        "libphonenumber-js": "^1.9.43",
+        "validator": "^13.7.0"
+      }
+    },
+    "node_modules/@medusajs/cache-inmemory/node_modules/glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@medusajs/cache-inmemory/node_modules/medusa-telemetry": {
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/medusa-telemetry/-/medusa-telemetry-0.0.16.tgz",
+      "integrity": "sha512-i9FVCfILzVQXXYuPCNf4h9BwTqi1uVyL08zzKLTCq/ttodyMb77TmnvolrE5XuvLsRbw3iqQ3aGq+sn0aURaVQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "axios": "^0.21.1",
+        "axios-retry": "^3.1.9",
+        "boxen": "^5.0.1",
+        "ci-info": "^3.2.0",
+        "configstore": "5.0.1",
+        "global": "^4.4.0",
+        "is-docker": "^2.2.1",
+        "remove-trailing-slash": "^0.1.1",
+        "uuid": "^8.3.2"
+      }
+    },
+    "node_modules/@medusajs/cache-inmemory/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@medusajs/core-flows": {

--- a/var/www/medusa-backend/package.json
+++ b/var/www/medusa-backend/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "@medusajs/admin": "^7.1.18",
+    "@medusajs/cache-inmemory": "^1.8.0",
     "@medusajs/event-bus-local": "^1.8.0",
     "@medusajs/medusa": "^1.7.8",
     "dotenv": "^17.2.1",


### PR DESCRIPTION
## Summary
- add `@medusajs/cache-inmemory` dependency
- register in-memory cache plugin in Medusa config

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689b491eeb0c83219b3b752bc50bcfad