### PR TITLE
Fix module configuration and hero layout

### DIFF
--- a/var/www/frontend-next/app/page.tsx
+++ b/var/www/frontend-next/app/page.tsx
@@ -6,7 +6,7 @@ export default function HomePage() {
     <main>
       <LookbookCarousel />
       <section className="container mx-auto px-4">
-        <h2 className="text-2xl font-bold mt-8 mb-4 tracking-wider">Featured products</h2>
+        <h2 className="text-2xl font-bold mt-4 mb-4 tracking-wider">Featured products</h2>
         <FeaturedProducts />
       </section>
     </main>

--- a/var/www/frontend-next/components/LookbookCarouselClient.tsx
+++ b/var/www/frontend-next/components/LookbookCarouselClient.tsx
@@ -24,36 +24,34 @@ export default function LookbookCarouselClient({ items }: { items: LookbookItem[
   const shouldLoop = items.length > 1
 
   return (
-    <Swiper
-      loop={shouldLoop}
-      watchOverflow
-      className="w-full h-[60vh] md:h-[80vh]"
-    >
-      {items.map((item, index) => (
-        <SwiperSlide key={`${item.title}-${index}`} className="h-full">
-          <div className="relative w-full h-full hero-zoom">
-            <Image
-              src={item.url}
-              alt={item.title}
-              fill
-              sizes="100vw"
-              className="object-cover"
-              priority={index === 0}
-            />
-            <div className="absolute inset-0 bg-black/40 flex flex-col items-center justify-center text-white">
-              <h2 className="text-2xl md:text-4xl font-bold mb-4 tracking-wider">
-                {item.season} Lookbook
-              </h2>
-              <Link
-                href="/shop"
-                className="underline text-3xl md:text-5xl font-bold"
-              >
-                Shop now
-              </Link>
+    <div className="w-full h-[60vh] md:h-[80vh]">
+      <Swiper loop={shouldLoop} watchOverflow className="w-full h-full">
+        {items.map((item, index) => (
+          <SwiperSlide key={`${item.title}-${index}`} className="h-full">
+            <div className="relative w-full h-full hero-zoom">
+              <Image
+                src={item.url}
+                alt={item.title}
+                fill
+                sizes="100vw"
+                className="object-cover"
+                priority={index === 0}
+              />
+              <div className="absolute inset-0 bg-black/40 flex flex-col items-center justify-center text-white">
+                <h2 className="text-2xl md:text-4xl font-bold mb-4 tracking-wider">
+                  {item.season} Lookbook
+                </h2>
+                <Link
+                  href="/shop"
+                  className="underline text-3xl md:text-5xl font-bold"
+                >
+                  Shop now
+                </Link>
+              </div>
             </div>
-          </div>
-        </SwiperSlide>
-      ))}
-    </Swiper>
+          </SwiperSlide>
+        ))}
+      </Swiper>
+    </div>
   )
 }

--- a/var/www/frontend-next/components/LookbookSkeleton.tsx
+++ b/var/www/frontend-next/components/LookbookSkeleton.tsx
@@ -3,5 +3,5 @@
 import Skeleton from './Skeleton'
 
 export default function LookbookSkeleton() {
-  return <Skeleton className="w-full h-[60vh] md:h-[80vh]" />
+  return <Skeleton className="w-full h-full" />
 }

--- a/var/www/medusa-backend/medusa-config.js
+++ b/var/www/medusa-backend/medusa-config.js
@@ -15,8 +15,6 @@ module.exports = {
     './plugins/cod',
     'medusa-fulfillment-manual',
     './admin-extensions',
-    '@medusajs/event-bus-local',
-    '@medusajs/cache-inmemory',
     {
       resolve: 'medusa-file-local',
       options: {
@@ -43,5 +41,9 @@ module.exports = {
         backend: process.env.MEDUSA_ADMIN_BACKEND_URL || 'http://localhost:7001'
       }
     }
+  ],
+  modules: [
+    '@medusajs/event-bus-local',
+    '@medusajs/cache-inmemory'
   ]
 }


### PR DESCRIPTION
## Summary
- Load cache and event bus as Medusa modules instead of plugins to prevent crashes
- Ensure Lookbook hero carousel fills its container without extra gaps

## Testing
- `npm test` (medusa-backend) *(fails: Missing script "test")*
- `npm test` (frontend-next) *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_689b53183c2083218d2941b800786ce2