### PR TITLE
Fix Lookbook carousel vertical offset

### DIFF
--- a/var/www/frontend-next/components/LookbookCarouselClient.tsx
+++ b/var/www/frontend-next/components/LookbookCarouselClient.tsx
@@ -24,8 +24,8 @@ export default function LookbookCarouselClient({ items }: { items: LookbookItem[
   const shouldLoop = items.length > 1
 
   return (
-    <div className="w-full h-[60vh] md:h-[80vh]">
-      <Swiper loop={shouldLoop} watchOverflow className="w-full h-full">
+    <div className="relative w-full h-[60vh] md:h-[80vh] overflow-hidden">
+      <Swiper loop={shouldLoop} watchOverflow className="absolute inset-0">
         {items.map((item, index) => (
           <SwiperSlide key={`${item.title}-${index}`} className="h-full">
             <div className="relative w-full h-full hero-zoom">


### PR DESCRIPTION
## Summary
- ensure Lookbook carousel fills hero container by positioning Swiper absolutely within a relative wrapper

## Testing
- `npm run lint`
- `npm run build` *(fails: connect ENETUNREACH zooizjud.api.sanity.io)*

------
https://chatgpt.com/codex/tasks/task_b_689b725d037c8321a7eb889a8210097b