### PR TITLE
Fix hero carousel stacking and height

### DIFF
--- a/var/www/frontend-next/app/page.tsx
+++ b/var/www/frontend-next/app/page.tsx
@@ -5,7 +5,7 @@ export default function HomePage() {
   return (
     <main>
       <LookbookCarousel />
-      <section className="container mx-auto px-4">
+      <section className="relative z-0 container mx-auto px-4">
         <h2 className="text-2xl font-bold mt-4 mb-4 tracking-wider">Featured products</h2>
         <FeaturedProducts />
       </section>

--- a/var/www/frontend-next/components/LookbookCarouselClient.tsx
+++ b/var/www/frontend-next/components/LookbookCarouselClient.tsx
@@ -24,8 +24,8 @@ export default function LookbookCarouselClient({ items }: { items: LookbookItem[
   const shouldLoop = items.length > 1
 
   return (
-    <div className="relative w-full h-[60vh] md:h-[80vh] overflow-hidden">
-      <Swiper loop={shouldLoop} watchOverflow className="absolute inset-0">
+    <section className="relative z-10 w-full h-[60vh] md:h-[80vh] overflow-hidden">
+      <Swiper loop={shouldLoop} watchOverflow className="h-full w-full">
         {items.map((item, index) => (
           <SwiperSlide key={`${item.title}-${index}`} className="h-full">
             <div className="relative w-full h-full hero-zoom">
@@ -52,6 +52,6 @@ export default function LookbookCarouselClient({ items }: { items: LookbookItem[
           </SwiperSlide>
         ))}
       </Swiper>
-    </div>
+    </section>
   )
 }


### PR DESCRIPTION
## Summary
- remove absolute positioning from hero Swiper and ensure full-height slides
- add z-index guards to hero and featured products sections

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_689ba91563a88321888fb5395b3481ff