### PR TITLE
Enable automatic admin UI build for Medusa

### DIFF
--- a/var/www/medusa-backend/medusa-config.js
+++ b/var/www/medusa-backend/medusa-config.js
@@ -28,6 +28,7 @@ module.exports = {
         path: '/app',
         serve: true,
         backend: process.env.MEDUSA_ADMIN_BACKEND_URL || 'http://localhost:7001',
+        autoRebuild: true,
       },
     },
   ],


### PR DESCRIPTION
## Summary
- automatically rebuild Medusa admin UI at startup so missing build files no longer crash the service

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_689bab3c85988321b522d97c99195c01