### PR TITLE
Add basic npm test script for medusa backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 .env.local
 var/www/medusa-backend/uploads/*
 !var/www/medusa-backend/uploads/.gitkeep
+var/www/sanity-studio/package-lock.json

--- a/var/www/medusa-backend/package.json
+++ b/var/www/medusa-backend/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "start": "npx medusa start",
     "seed": "npx medusa seed -f ./data/seed.json",
-    "migrate": "npx medusa migrations run"
+    "migrate": "npx medusa migrations run",
+    "test": "node test/test.js"
   },
   "dependencies": {
     "@medusajs/admin": "^7.1.18",

--- a/var/www/medusa-backend/test/test.js
+++ b/var/www/medusa-backend/test/test.js
@@ -1,0 +1,5 @@
+const assert = require('assert')
+
+assert.strictEqual(1 + 1, 2)
+
+console.log('tests passed')


### PR DESCRIPTION
## Summary
- ignore sanity studio lockfile
- add npm test script and simple assertion

## Testing
- `cd var/www/medusa-backend && npm test`

------
https://chatgpt.com/codex/tasks/task_b_689bacfd6ef8832196785728b4d59dc1