### PR TITLE
feat: add suspense fallback to lookbook carousel

### DIFF
--- a/var/www/frontend-next/components/LookbookCarouselClient.tsx
+++ b/var/www/frontend-next/components/LookbookCarouselClient.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { Suspense } from 'react'
 import dynamic from 'next/dynamic'
 import Image from 'next/image'
 import Link from 'next/link'
@@ -7,11 +8,11 @@ import LookbookSkeleton from './LookbookSkeleton'
 
 const Swiper = dynamic(
   () => import('swiper/react').then((m) => m.Swiper),
-  { ssr: false, loading: () => <LookbookSkeleton /> }
+  { suspense: true }
 )
 const SwiperSlide = dynamic(
   () => import('swiper/react').then((m) => m.SwiperSlide),
-  { ssr: false }
+  { suspense: true }
 )
 
 interface LookbookItem {
@@ -24,34 +25,36 @@ export default function LookbookCarouselClient({ items }: { items: LookbookItem[
   const shouldLoop = items.length > 1
 
   return (
-    <section className="relative z-10 w-full h-[60vh] md:h-[80vh] overflow-hidden">
-      <Swiper loop={shouldLoop} watchOverflow className="h-full w-full">
-        {items.map((item, index) => (
-          <SwiperSlide key={`${item.title}-${index}`} className="h-full">
-            <div className="relative w-full h-full hero-zoom">
-              <Image
-                src={item.url}
-                alt={item.title}
-                fill
-                sizes="100vw"
-                className="object-cover"
-                priority={index === 0}
-              />
-              <div className="absolute inset-0 bg-black/40 flex flex-col items-center justify-center text-white">
-                <h2 className="text-2xl md:text-4xl font-bold mb-4 tracking-wider">
-                  {item.season} Lookbook
-                </h2>
-                <Link
-                  href="/shop"
-                  className="underline text-3xl md:text-5xl font-bold"
-                >
-                  Shop now
-                </Link>
+    <section className='relative z-10 w-full h-[60vh] md:h-[80vh] overflow-hidden'>
+      <Suspense fallback={<LookbookSkeleton />}>
+        <Swiper loop={shouldLoop} watchOverflow className='h-full w-full'>
+          {items.map((item, index) => (
+            <SwiperSlide key={`${item.title}-${index}`} className='h-full'>
+              <div className='relative w-full h-full hero-zoom'>
+                <Image
+                  src={item.url}
+                  alt={item.title}
+                  fill
+                  sizes='100vw'
+                  className='object-cover'
+                  priority={index === 0}
+                />
+                <div className='absolute inset-0 bg-black/40 flex flex-col items-center justify-center text-white'>
+                  <h2 className='text-2xl md:text-4xl font-bold mb-4 tracking-wider'>
+                    {item.season} Lookbook
+                  </h2>
+                  <Link
+                    href='/shop'
+                    className='underline text-3xl md:text-5xl font-bold'
+                  >
+                    Shop now
+                  </Link>
+                </div>
               </div>
-            </div>
-          </SwiperSlide>
-        ))}
-      </Swiper>
+            </SwiperSlide>
+          ))}
+        </Swiper>
+      </Suspense>
     </section>
   )
 }


### PR DESCRIPTION
## Summary
- wrap Swiper carousel with Suspense fallback so server output reserves space and hydrates in place

## Testing
- `npm test` in `var/www/medusa-backend`
- `npm run lint` in `var/www/frontend-next`
- `npm run build` *(fails: fetch failed for Sanity and Medusa endpoints)*

------
https://chatgpt.com/codex/tasks/task_b_689bb6d02a9883218f9b55efd3609b5d