### PR TITLE
feat: improve lookbook carousel loading

### DIFF
--- a/var/www/frontend-next/components/LookbookCarouselClient.tsx
+++ b/var/www/frontend-next/components/LookbookCarouselClient.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { Suspense } from 'react'
 import dynamic from 'next/dynamic'
 import Image from 'next/image'
 import Link from 'next/link'
@@ -8,11 +7,11 @@ import LookbookSkeleton from './LookbookSkeleton'
 
 const Swiper = dynamic(
   () => import('swiper/react').then((m) => m.Swiper),
-  { suspense: true }
+  { ssr: false, loading: () => <LookbookSkeleton /> }
 )
 const SwiperSlide = dynamic(
   () => import('swiper/react').then((m) => m.SwiperSlide),
-  { suspense: true }
+  { ssr: false, loading: () => <LookbookSkeleton /> }
 )
 
 interface LookbookItem {
@@ -26,35 +25,33 @@ export default function LookbookCarouselClient({ items }: { items: LookbookItem[
 
   return (
     <section className='relative z-10 w-full h-[60vh] md:h-[80vh] overflow-hidden'>
-      <Suspense fallback={<LookbookSkeleton />}>
-        <Swiper loop={shouldLoop} watchOverflow className='h-full w-full'>
-          {items.map((item, index) => (
-            <SwiperSlide key={`${item.title}-${index}`} className='h-full'>
-              <div className='relative w-full h-full hero-zoom'>
-                <Image
-                  src={item.url}
-                  alt={item.title}
-                  fill
-                  sizes='100vw'
-                  className='object-cover'
-                  priority={index === 0}
-                />
-                <div className='absolute inset-0 bg-black/40 flex flex-col items-center justify-center text-white'>
-                  <h2 className='text-2xl md:text-4xl font-bold mb-4 tracking-wider'>
-                    {item.season} Lookbook
-                  </h2>
-                  <Link
-                    href='/shop'
-                    className='underline text-3xl md:text-5xl font-bold'
-                  >
-                    Shop now
-                  </Link>
-                </div>
+      <Swiper loop={shouldLoop} watchOverflow className='h-full w-full'>
+        {items.map((item, index) => (
+          <SwiperSlide key={`${item.title}-${index}`} className='h-full'>
+            <div className='relative w-full h-full hero-zoom'>
+              <Image
+                src={item.url}
+                alt={item.title}
+                fill
+                sizes='100vw'
+                className='object-cover'
+                priority={index === 0}
+              />
+              <div className='absolute inset-0 bg-black/40 flex flex-col items-center justify-center text-white'>
+                <h2 className='text-2xl md:text-4xl font-bold mb-4 tracking-wider'>
+                  {item.season} Lookbook
+                </h2>
+                <Link
+                  href='/shop'
+                  className='underline text-3xl md:text-5xl font-bold'
+                >
+                  Shop now
+                </Link>
               </div>
-            </SwiperSlide>
-          ))}
-        </Swiper>
-      </Suspense>
+            </div>
+          </SwiperSlide>
+        ))}
+      </Swiper>
     </section>
   )
 }


### PR DESCRIPTION
## Summary
- remove Suspense and use dynamic imports with `ssr: false` and `LookbookSkeleton` placeholders for Swiper components
- preserve carousel section height to keep hero space during hydration

## Testing
- `npm test` in `var/www/medusa-backend`
- `npm run build` in `var/www/frontend-next` *(fails: fetch failed to Sanity API and local Medusa API)*

------
https://chatgpt.com/codex/tasks/task_b_689bc211c4008321947518f4adcfcee2