### PR TITLE
Allow Next.js to load Medusa uploads from localhost:9000

### DIFF
--- a/var/www/frontend-next/next.config.js
+++ b/var/www/frontend-next/next.config.js
@@ -14,6 +14,12 @@ const nextConfig = {
         pathname: '/**'
       },
       {
+        protocol: 'http',
+        hostname: 'localhost',
+        port: '9000',
+        pathname: '/uploads/**'
+      },
+      {
         protocol: 'https',
         hostname: 'cdn.sanity.io',
         pathname: '/**'


### PR DESCRIPTION
## Summary
- allow product images served from Medusa on localhost:9000

## Testing
- `cd var/www/medusa-backend && npm test`


------
https://chatgpt.com/codex/tasks/task_b_689bc3ef91a88321a0ab14409be027ce