### PR TITLE
Fix lookbook Swiper structure and height

### DIFF
--- a/var/www/frontend-next/components/LookbookCarouselClient.tsx
+++ b/var/www/frontend-next/components/LookbookCarouselClient.tsx
@@ -1,18 +1,8 @@
 'use client'
 
-import dynamic from 'next/dynamic'
 import Image from 'next/image'
 import Link from 'next/link'
-import LookbookSkeleton from './LookbookSkeleton'
-
-const Swiper = dynamic(
-  () => import('swiper/react').then((m) => m.Swiper),
-  { ssr: false, loading: () => <LookbookSkeleton /> }
-)
-const SwiperSlide = dynamic(
-  () => import('swiper/react').then((m) => m.SwiperSlide),
-  { ssr: false, loading: () => <LookbookSkeleton /> }
-)
+import { Swiper, SwiperSlide } from 'swiper/react'
 
 interface LookbookItem {
   title: string

--- a/var/www/frontend-next/components/LookbookSkeleton.tsx
+++ b/var/www/frontend-next/components/LookbookSkeleton.tsx
@@ -1,7 +1,0 @@
-"use client"
-
-import Skeleton from './Skeleton'
-
-export default function LookbookSkeleton() {
-  return <Skeleton className="w-full h-full" />
-}


### PR DESCRIPTION
## Summary
- import Swiper components directly so slides mount within wrapper
- remove unused lookbook skeleton

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689bc91a5ff08321a229f99ee62f0ee3