### PR TITLE
feat: enhance navbar animations

### DIFF
--- a/var/www/frontend-next/components/Navbar.tsx
+++ b/var/www/frontend-next/components/Navbar.tsx
@@ -1,51 +1,91 @@
-"use client"
-import { useState } from "react"
-import Image from "next/image"
-import Link from "next/link"
-import dynamic from "next/dynamic"
-import { FaBars, FaShoppingCart, FaSearch } from "react-icons/fa"
-import { useCart } from "../lib/store"
+'use client'
 
-const MobileMenu = dynamic(() => import("./MobileMenu"), { ssr: false })
+import { useState, useEffect } from 'react'
+import Image from 'next/image'
+import Link from 'next/link'
+import dynamic from 'next/dynamic'
+import { usePathname } from 'next/navigation'
+import { FaBars, FaShoppingCart, FaSearch } from 'react-icons/fa'
+import { useCart } from '../lib/store'
+
+const MobileMenu = dynamic(() => import('./MobileMenu'), { ssr: false })
+
+const links = [
+  { href: '/', label: 'Home' },
+  { href: '/shop', label: 'Shop' }
+]
 
 export default function Navbar() {
-  const cartQuantity = useCart((state) => state.totalItems())
+  const pathname = usePathname()
+  const cartQuantity = useCart(state => state.totalItems())
   const [menuOpen, setMenuOpen] = useState(false)
+  const [scrolled, setScrolled] = useState(false)
+  const [bump, setBump] = useState(false)
+
+  useEffect(() => {
+    const onScroll = () => setScrolled(window.scrollY > 0)
+    window.addEventListener('scroll', onScroll)
+    return () => window.removeEventListener('scroll', onScroll)
+  }, [])
+
+  useEffect(() => {
+    if (cartQuantity === 0) return
+    setBump(true)
+    const t = setTimeout(() => setBump(false), 300)
+    return () => clearTimeout(t)
+  }, [cartQuantity])
 
   return (
-    <header className="sticky top-0 z-50 bg-white border-b border-gray-200">
-      <nav className="grid grid-cols-3 items-center h-16 px-4">
-        <div className="flex items-center gap-6">
-          <button className="md:hidden hover:text-white hover:bg-black p-1 rounded" onClick={() => setMenuOpen(true)}>
+    <header className={`sticky top-0 z-50 backdrop-blur bg-white/70 border-b border-white/20 transition-shadow ${scrolled ? 'shadow-md' : ''}`}>
+      <nav className='grid grid-cols-3 items-center h-16 px-4'>
+        <div className='flex items-center gap-6'>
+          <button className='md:hidden p-1 rounded hover:bg-black hover:text-white' onClick={() => setMenuOpen(true)}>
             <FaBars />
           </button>
-          <div className="hidden md:flex items-center gap-6">
-            <Link href="/" className="hover:underline decoration-gray-300">Home</Link>
-            <Link href="/shop" className="hover:underline decoration-gray-300">Shop</Link>
+          <div className='hidden md:flex items-center gap-6'>
+            {links.map(l => {
+              const active = pathname === l.href
+              return (
+                <Link
+                  key={l.href}
+                  href={l.href}
+                  aria-current={active ? 'page' : undefined}
+                  className='group relative px-2 py-1'
+                >
+                  <span className={`transition-all ${active ? 'font-bold' : ''} group-hover:tracking-wider group-hover:-translate-y-0.5`}>{l.label}</span>
+                  <span className='absolute inset-0 rounded-full bg-black/5 opacity-0 group-hover:opacity-100 transition-opacity' />
+                  <span
+                    className={`absolute bottom-0 h-0.5 bg-black transition-all origin-center ${active ? 'w-full' : 'w-0 group-hover:w-full'} left-1/2 -translate-x-1/2 rtl:left-auto rtl:right-1/2 rtl:translate-x-1/2`}
+                  />
+                </Link>
+              )
+            })}
           </div>
         </div>
-        <div className="justify-self-center">
-          <Link href="/">
-            <div className="relative h-12 w-28 overflow-hidden">
+        <div className='justify-self-center'>
+          <Link href='/'>
+            <div className='relative h-12 w-28 overflow-hidden'>
               <Image
-                src="/logo.svg"
-                alt="nabd.dhk logo"
+                src='/logo.svg'
+                alt='nabd.dhk logo'
                 fill
-                className="object-cover"
+                className='object-cover'
                 priority
-                sizes="7rem"
+                sizes='7rem'
               />
             </div>
           </Link>
         </div>
-        <div className="justify-self-end flex items-center gap-6">
-          <Link href="/search" aria-label="Search" className="hover:text-white hover:bg-black p-1 rounded">
-            <FaSearch />
+        <div className='justify-self-end flex items-center gap-6'>
+          <Link href='/search' aria-label='Search' className='group relative p-1 rounded hover:bg-black hover:text-white'>
+            <FaSearch className='group-hover:animate-micro-bounce' />
           </Link>
-          <Link href="/cart" aria-label="Cart" className="relative hover:text-white hover:bg-black p-1 rounded">
-            <FaShoppingCart />
+          <Link href='/cart' aria-label='Cart' className='group relative p-1 rounded hover:bg-black hover:text-white'>
+            <FaShoppingCart className='group-hover:animate-micro-bounce' />
             {cartQuantity > 0 && (
-              <span className="absolute -top-2 -right-2 bg-red-500 text-white rounded-full text-xs w-4 h-4 flex items-center justify-center">
+              <span
+                className={`absolute -top-2 -right-2 flex h-4 w-4 items-center justify-center rounded-full bg-red-500 text-xs text-white ${bump ? 'animate-bump' : ''}`}
+              >
                 {cartQuantity}
               </span>
             )}
@@ -56,3 +96,4 @@ export default function Navbar() {
     </header>
   )
 }
+

--- a/var/www/frontend-next/tailwind.config.js
+++ b/var/www/frontend-next/tailwind.config.js
@@ -15,6 +15,23 @@ module.exports = {
           800: '#1f2937',
           900: '#111827'
         }
+      },
+      keyframes: {
+        bump: {
+          '0%': { transform: 'scale(1)' },
+          '10%': { transform: 'scale(1.1)' },
+          '30%': { transform: 'scale(1.15)' },
+          '50%': { transform: 'scale(1.1)' },
+          '100%': { transform: 'scale(1)' }
+        },
+        'micro-bounce': {
+          '0%,100%': { transform: 'translateY(0)' },
+          '50%': { transform: 'translateY(-2px)' }
+        }
+      },
+      animation: {
+        bump: 'bump 0.3s',
+        'micro-bounce': 'micro-bounce 0.3s'
       }
     }
   },


### PR DESCRIPTION
## Summary
- animate navbar links with center-growing underline and pill hover effect
- add sticky glass-style navbar with scroll shadow and RTL-aware indicators
- introduce micro-bounce search/cart icons and animated cart badge

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_689bd267994883218e1a082f8f604d50