### PR TITLE
feat: refine lookbook carousel

### DIFF
--- a/var/www/frontend-next/app/globals.css
+++ b/var/www/frontend-next/app/globals.css
@@ -56,10 +56,7 @@
 
 @keyframes heroZoom {
   0% {
-    transform: scale(1.08);
-  }
-  50% {
-    transform: scale(0.97);
+    transform: scale(1.1);
   }
   100% {
     transform: scale(1);
@@ -67,7 +64,27 @@
 }
 
 .hero-zoom {
-  animation: heroZoom 1600ms ease-out both;
+  animation: heroZoom 2000ms ease-out both;
+}
+
+.underline-from-center {
+  position: relative;
+}
+
+.underline-from-center::after {
+  content: '';
+  position: absolute;
+  bottom: -2px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 0;
+  height: 2px;
+  background-color: currentColor;
+  transition: width 300ms ease;
+}
+
+.underline-from-center:hover::after {
+  width: 100%;
 }
 
 .swiper,

--- a/var/www/frontend-next/components/LookbookCarouselClient.tsx
+++ b/var/www/frontend-next/components/LookbookCarouselClient.tsx
@@ -1,45 +1,41 @@
-'use client';
+'use client'
 
-import Image from 'next/image';
-import Link from 'next/link';
-import { Swiper, SwiperSlide } from 'swiper/react';
+import Image from 'next/image'
+import Link from 'next/link'
+import { Swiper, SwiperSlide } from 'swiper/react'
 
 interface LookbookItem {
-  title: string;
-  season: string;
-  url: string;
+  title: string
+  season: string
+  url: string
 }
 
-export default function LookbookCarouselClient({
-  items,
-}: {
-  items: LookbookItem[];
-}) {
-  const shouldLoop = items.length > 1;
+export default function LookbookCarouselClient({ items }: { items: LookbookItem[] }) {
+  const shouldLoop = items.length > 1
 
   return (
-    <section className="relative z-10 w-full h-[60vh] md:h-[80vh] overflow-hidden">
-      <Swiper loop={shouldLoop} watchOverflow className="h-full w-full">
+    <section className='relative z-10 w-full aspect-[4/5] md:aspect-video overflow-hidden'>
+      <Swiper loop={shouldLoop} watchOverflow className='h-full w-full'>
         {items.map((item, index) => (
-          <SwiperSlide key={`${item.title}-${index}`} className="h-full">
-            <div className="relative w-full h-full hero-zoom">
+          <SwiperSlide key={`${item.title}-${index}`} className='h-full'>
+            <div className='relative w-full h-full hero-zoom'>
               <Image
                 src={item.url}
                 alt={item.title}
                 fill
-                sizes="100vw"
-                className="object-cover"
+                sizes='100vw'
+                className='object-cover'
                 priority={index === 0}
               />
-              <div className="absolute inset-0 bg-black/40 flex flex-col items-center justify-center text-white">
-                <h2 className="text-2xl md:text-4xl font-bold mb-4 tracking-brand">
+              <div className='absolute inset-0 bg-gradient-to-t from-black/50 to-transparent flex flex-col items-center justify-center text-white'>
+                <h2 className='text-2xl md:text-4xl font-bold mb-4 tracking-brand'>
                   {item.season} Lookbook
                 </h2>
                 <Link
-                  href="/shop"
-                  className="underline text-3xl md:text-4xl font-bold tracking-brand"
+                  href='/shop'
+                  className='underline-from-center text-3xl md:text-4xl font-bold tracking-brand'
                 >
-                  Shop now
+                  Shop Now
                 </Link>
               </div>
             </div>
@@ -47,5 +43,6 @@ export default function LookbookCarouselClient({
         ))}
       </Swiper>
     </section>
-  );
+  )
 }
+


### PR DESCRIPTION
## Summary
- enforce 4:5 mobile and 16:9 desktop ratios for lookbook carousel
- add gradient overlay, ken burns zoom and animated underline link
- tweak hero zoom animation duration and style

## Testing
- `cd var/www/medusa-backend && npm test >/tmp/test.log && tail -n 20 /tmp/test.log`

------
https://chatgpt.com/codex/tasks/task_b_689e4301907c83218692a6533fd30be9