### PR TITLE
feat(frontend): add cart empty state component

### DIFF
--- a/var/www/frontend-next/app/cart/page.tsx
+++ b/var/www/frontend-next/app/cart/page.tsx
@@ -1,95 +1,77 @@
-'use client';
-import Image from 'next/image';
-import Link from 'next/link';
-import { FaTrash } from 'react-icons/fa';
-import { useCart } from '../../lib/store';
+'use client'
+import Image from 'next/image'
+import Link from 'next/link'
+import { FaTrash } from 'react-icons/fa'
+import { useCart } from '../../lib/store'
+import CartEmptyState from '../../components/CartEmptyState'
 
 export default function CartPage() {
-  const { items, updateQuantity, totalItems, totalPrice } = useCart();
+  const { items, updateQuantity, totalItems, totalPrice } = useCart()
 
   return (
-    <main className="p-8 space-y-4">
-      <h1 className="text-3xl font-bold mb-4 tracking-brand">Cart</h1>
+    <main className='p-8 space-y-4'>
+      <h1 className='text-3xl font-bold mb-4 tracking-brand'>Cart</h1>
       {items.length === 0 ? (
-        <div className="flex flex-col items-center justify-center py-20 space-y-6">
-          <Image
-            src="/placeholder.svg"
-            alt="Empty cart"
-            width={200}
-            height={200}
-          />
-          <Link href="/" className="px-4 py-2 border border-black">
-            View Products
-          </Link>
-        </div>
+        <CartEmptyState />
       ) : (
         <>
-          <div className="overflow-x-auto">
-            <table className="w-full border-collapse">
+          <div className='overflow-x-auto'>
+            <table className='w-full border-collapse'>
               <thead>
-                <tr className="border-b border-gray-200 text-sm">
-                  <th className="p-2 text-left">Item</th>
-                  <th className="p-2">Quantity</th>
-                  <th className="p-2">Unit Price</th>
-                  <th className="p-2">Total</th>
-                  <th className="p-2" />
+                <tr className='border-b border-gray-200 text-sm'>
+                  <th className='p-2 text-left'>Item</th>
+                  <th className='p-2'>Quantity</th>
+                  <th className='p-2'>Unit Price</th>
+                  <th className='p-2'>Total</th>
+                  <th className='p-2' />
                 </tr>
               </thead>
               <tbody>
                 {items.map((item, i) => (
-                  <tr key={i} className="border-b border-gray-200">
-                    <td className="p-2">
-                      <div className="flex items-center gap-4">
+                  <tr key={i} className='border-b border-gray-200'>
+                    <td className='p-2'>
+                      <div className='flex items-center gap-4'>
                         <Image
                           src={item.image || '/placeholder.svg'}
                           alt={item.title}
                           width={60}
                           height={60}
-                          className="object-cover"
+                          className='object-cover'
                         />
-                        <span className="font-medium">{item.title}</span>
+                        <span className='font-medium'>{item.title}</span>
                       </div>
                     </td>
-                    <td className="p-2">
-                      <div className="flex items-center border rounded w-max">
+                    <td className='p-2'>
+                      <div className='flex items-center border rounded w-max'>
                         <button
-                          className="px-2"
-                          onClick={() =>
-                            updateQuantity(item.id, item.quantity - 1)
-                          }
-                          aria-label="Decrease quantity"
+                          className='px-2'
+                          onClick={() => updateQuantity(item.id, item.quantity - 1)}
+                          aria-label='Decrease quantity'
                         >
                           -
                         </button>
                         <input
-                          type="number"
+                          type='number'
                           min={1}
                           value={item.quantity}
-                          onChange={(e) =>
-                            updateQuantity(item.id, parseInt(e.target.value))
-                          }
-                          className="w-12 text-center border-l border-r"
+                          onChange={e => updateQuantity(item.id, parseInt(e.target.value))}
+                          className='w-12 text-center border-l border-r'
                         />
                         <button
-                          className="px-2"
-                          onClick={() =>
-                            updateQuantity(item.id, item.quantity + 1)
-                          }
-                          aria-label="Increase quantity"
+                          className='px-2'
+                          onClick={() => updateQuantity(item.id, item.quantity + 1)}
+                          aria-label='Increase quantity'
                         >
                           +
                         </button>
                       </div>
                     </td>
-                    <td className="p-2">${item.price.toFixed(2)}</td>
-                    <td className="p-2 font-semibold">
+                    <td className='p-2'>${item.price.toFixed(2)}</td>
+                    <td className='p-2 font-semibold'>
                       ${(item.price * item.quantity).toFixed(2)}
                     </td>
-                    <td className="p-2 text-center">
-                      <button
-                        onClick={() => updateQuantity(item.id, 0)}
-                        aria-label="Remove item"
-                      >
+                    <td className='p-2 text-center'>
+                      <button onClick={() => updateQuantity(item.id, 0)} aria-label='Remove item'>
                         <FaTrash />
                       </button>
                     </td>
@@ -98,20 +80,23 @@ export default function CartPage() {
               </tbody>
             </table>
           </div>
-          <div className="flex justify-between items-center font-semibold pt-4">
+          <div className='flex justify-between items-center font-semibold pt-4'>
             <span>Subtotal ({totalItems()} items)</span>
-            <span className="text-xl">${totalPrice().toFixed(2)}</span>
+            <span className='text-xl'>${totalPrice().toFixed(2)}</span>
           </div>
-            <div className='flex gap-4 pt-4'>
-              <Link href='/' className='px-4 py-2 border border-black rounded-md'>
-                Continue Shopping
-              </Link>
-              <Link href='/checkout' className='px-4 py-2 bg-accent text-white rounded-md hover:bg-accent/90'>
-                Checkout
-              </Link>
-            </div>
+          <div className='flex gap-4 pt-4'>
+            <Link href='/' className='px-4 py-2 border border-black rounded-md'>
+              Continue Shopping
+            </Link>
+            <Link
+              href='/checkout'
+              className='px-4 py-2 bg-accent text-white rounded-md hover:bg-accent/90'
+            >
+              Checkout
+            </Link>
+          </div>
         </>
       )}
     </main>
-  );
+  )
 }

--- a/var/www/frontend-next/components/CartDrawer.tsx
+++ b/var/www/frontend-next/components/CartDrawer.tsx
@@ -2,6 +2,7 @@
 import { useState } from 'react'
 import { FaTimes } from 'react-icons/fa'
 import { useCart } from '../lib/store'
+import CartEmptyState from './CartEmptyState'
 
 export default function CartDrawer() {
   const { items, totalItems, totalPrice } = useCart()
@@ -29,7 +30,7 @@ export default function CartDrawer() {
         </button>
         <h2 className="font-bold">Your Cart ({totalItems()} items)</h2>
         {items.length === 0 ? (
-          <p>Shopping cart is empty!</p>
+          <CartEmptyState />
         ) : (
           <>
             <ul className="space-y-2">

--- a/var/www/frontend-next/components/CartEmptyState.tsx
+++ b/var/www/frontend-next/components/CartEmptyState.tsx
@@ -1,0 +1,15 @@
+'use client'
+import Image from 'next/image'
+import Link from 'next/link'
+
+export default function CartEmptyState() {
+  return (
+    <div className='flex flex-col items-center justify-center py-20 space-y-6 text-center'>
+      <Image src='/logo.svg' alt='Empty cart' width={120} height={120} />
+      <p className='text-xl font-semibold'>Your cart is empty</p>
+      <Link href='/' className='px-4 py-2 border border-black rounded-md'>
+        Continue Shopping
+      </Link>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add reusable CartEmptyState component with branding and call to action
- integrate CartEmptyState into cart page and drawer

## Testing
- `cd var/www/medusa-backend && npm test`


------
https://chatgpt.com/codex/tasks/task_b_689e469b61608321abd6206c6fb0eedd