### PR TITLE
feat: animate cart empty state

### DIFF
--- a/var/www/frontend-next/app/cart/page.tsx
+++ b/var/www/frontend-next/app/cart/page.tsx
@@ -2,18 +2,23 @@
 import Image from 'next/image'
 import Link from 'next/link'
 import { FaTrash } from 'react-icons/fa'
+import { useEffect, useState } from 'react'
 import { useCart } from '../../lib/store'
 import CartEmptyState from '../../components/CartEmptyState'
 
 export default function CartPage() {
   const { items, updateQuantity, totalItems, totalPrice } = useCart()
+  const [showEmpty, setShowEmpty] = useState(items.length === 0)
+
+  useEffect(() => {
+    setShowEmpty(items.length === 0)
+  }, [items.length])
 
   return (
     <main className='p-8 space-y-4'>
       <h1 className='text-3xl font-bold mb-4 tracking-brand'>Cart</h1>
-      {items.length === 0 ? (
-        <CartEmptyState />
-      ) : (
+      <CartEmptyState show={showEmpty} />
+      {!showEmpty && (
         <>
           <div className='overflow-x-auto'>
             <table className='w-full border-collapse'>

--- a/var/www/frontend-next/components/CartDrawer.tsx
+++ b/var/www/frontend-next/components/CartDrawer.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { FaTimes } from 'react-icons/fa'
 import { useCart } from '../lib/store'
 import CartEmptyState from './CartEmptyState'
@@ -7,6 +7,11 @@ import CartEmptyState from './CartEmptyState'
 export default function CartDrawer() {
   const { items, totalItems, totalPrice } = useCart()
   const [open, setOpen] = useState(true)
+  const [showEmpty, setShowEmpty] = useState(items.length === 0)
+
+  useEffect(() => {
+    setShowEmpty(items.length === 0)
+  }, [items.length])
 
   return (
     <>
@@ -28,14 +33,13 @@ export default function CartDrawer() {
         >
           <FaTimes />
         </button>
-        <h2 className="font-bold">Your Cart ({totalItems()} items)</h2>
-        {items.length === 0 ? (
-          <CartEmptyState />
-        ) : (
+        <h2 className='font-bold'>Your Cart ({totalItems()} items)</h2>
+        <CartEmptyState show={showEmpty} />
+        {!showEmpty && (
           <>
-            <ul className="space-y-2">
+            <ul className='space-y-2'>
               {items.map((item, i) => (
-                <li key={i} className="flex justify-between">
+                <li key={i} className='flex justify-between'>
                   <span>
                     {item.title} x {item.quantity}
                   </span>
@@ -43,7 +47,7 @@ export default function CartDrawer() {
                 </li>
               ))}
             </ul>
-            <div className="flex justify-between font-semibold border-t pt-2">
+            <div className='flex justify-between font-semibold border-t pt-2'>
               <span>Subtotal</span>
               <span>${totalPrice().toFixed(2)}</span>
             </div>

--- a/var/www/frontend-next/components/CartEmptyState.tsx
+++ b/var/www/frontend-next/components/CartEmptyState.tsx
@@ -1,10 +1,28 @@
 'use client'
 import Image from 'next/image'
 import Link from 'next/link'
+import { useEffect, useState } from 'react'
 
-export default function CartEmptyState() {
+type Props = {
+  show?: boolean
+}
+
+export default function CartEmptyState({ show = false }: Props) {
+  const [render, setRender] = useState(show)
+
+  useEffect(() => {
+    if (show) {
+      setRender(true)
+    } else {
+      const t = setTimeout(() => setRender(false), 200)
+      return () => clearTimeout(t)
+    }
+  }, [show])
+
   return (
-    <div className='flex flex-col items-center justify-center py-20 space-y-6 text-center'>
+    <div
+      className={`flex flex-col items-center justify-center py-20 space-y-6 text-center transition-all duration-200 transform ${show ? 'opacity-100 scale-100' : 'opacity-0 scale-95'} ${render ? '' : 'hidden'}`}
+    >
       <Image src='/logo.svg' alt='Empty cart' width={120} height={120} />
       <p className='text-xl font-semibold'>Your cart is empty</p>
       <Link href='/' className='px-4 py-2 border border-black rounded-md'>


### PR DESCRIPTION
## Summary
- add fade and scale transition to CartEmptyState
- animate cart empty state when switching between empty and filled

## Testing
- `npm test` in `var/www/medusa-backend`
- `npm test` in `var/www/frontend-next`


------
https://chatgpt.com/codex/tasks/task_b_689e49d7eb9c8321bbc6949e889d5141