### PR TITLE
feat: toggle cart drawer from navbar

### DIFF
--- a/var/www/frontend-next/components/CartDrawer.tsx
+++ b/var/www/frontend-next/components/CartDrawer.tsx
@@ -1,12 +1,16 @@
 'use client'
-import { useEffect, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { FaTimes } from 'react-icons/fa'
 import { useCart } from '../lib/store'
 import CartEmptyState from './CartEmptyState'
 
-export default function CartDrawer() {
+interface Props {
+  open: boolean
+  onClose: () => void
+}
+
+export default function CartDrawer({ open, onClose }: Props) {
   const { items, totalItems, totalPrice } = useCart()
-  const [open, setOpen] = useState(true)
   const [showEmpty, setShowEmpty] = useState(items.length === 0)
 
   useEffect(() => {
@@ -19,7 +23,7 @@ export default function CartDrawer() {
         className={`fixed inset-0 bg-black transition-opacity duration-300 ${
           open ? 'bg-opacity-50' : 'bg-opacity-0 pointer-events-none'
         }`}
-        onClick={() => setOpen(false)}
+        onClick={onClose}
       />
       <aside
         className={`fixed right-0 top-0 w-80 h-full bg-white shadow-md p-4 space-y-4 transform transition-transform duration-300 ${
@@ -28,7 +32,7 @@ export default function CartDrawer() {
       >
         <button
           className='absolute top-4 right-4 p-1 rounded-md text-black hover:bg-accent hover:text-white'
-          onClick={() => setOpen(false)}
+          onClick={onClose}
           aria-label='Close cart'
         >
           <FaTimes />

--- a/var/www/frontend-next/components/CartEmptyState.tsx
+++ b/var/www/frontend-next/components/CartEmptyState.tsx
@@ -1,7 +1,7 @@
 'use client'
 import Image from 'next/image'
 import Link from 'next/link'
-import { useEffect, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 
 type Props = {
   show?: boolean

--- a/var/www/frontend-next/components/Navbar.tsx
+++ b/var/www/frontend-next/components/Navbar.tsx
@@ -5,9 +5,10 @@ import Image from 'next/image';
 import Link from 'next/link';
 import dynamic from 'next/dynamic';
 import { usePathname } from 'next/navigation';
-import { FaBars, FaShoppingCart, FaSearch } from 'react-icons/fa';
-import { useCart } from '../lib/store';
-import SearchOverlay from './SearchOverlay';
+import { FaBars, FaShoppingCart, FaSearch } from 'react-icons/fa'
+import { useCart } from '../lib/store'
+import SearchOverlay from './SearchOverlay'
+import CartDrawer from './CartDrawer'
 
 const MobileMenu = dynamic(() => import('./MobileMenu'), { ssr: false });
 
@@ -18,11 +19,12 @@ const links = [
 
 export default function Navbar() {
   const pathname = usePathname();
-  const cartQuantity = useCart((state) => state.totalItems());
-  const [menuOpen, setMenuOpen] = useState(false);
-  const [scrolled, setScrolled] = useState(false);
-  const [bump, setBump] = useState(false);
-  const [searchOpen, setSearchOpen] = useState(false);
+  const cartQuantity = useCart(state => state.totalItems())
+  const [menuOpen, setMenuOpen] = useState(false)
+  const [scrolled, setScrolled] = useState(false)
+  const [bump, setBump] = useState(false)
+  const [searchOpen, setSearchOpen] = useState(false)
+  const [cartOpen, setCartOpen] = useState(false)
 
   useEffect(() => {
     const onScroll = () => setScrolled(window.scrollY > 0);
@@ -109,10 +111,10 @@ export default function Navbar() {
           >
             <FaSearch className='group-hover:animate-micro-bounce' />
           </button>
-          <Link
-            href='/cart'
-            aria-label='Cart'
+          <button
+            aria-label='Open cart'
             className='group relative p-1 rounded-md hover:bg-accent hover:text-white'
+            onClick={() => setCartOpen(o => !o)}
           >
             <FaShoppingCart className='group-hover:animate-micro-bounce' />
             {cartQuantity > 0 && (
@@ -122,7 +124,7 @@ export default function Navbar() {
                 {cartQuantity}
               </span>
             )}
-          </Link>
+          </button>
         </div>
       </nav>
       {menuOpen && (
@@ -131,6 +133,7 @@ export default function Navbar() {
       {searchOpen && (
         <SearchOverlay open={searchOpen} onClose={() => setSearchOpen(false)} />
       )}
+      <CartDrawer open={cartOpen} onClose={() => setCartOpen(false)} />
     </header>
-  );
+  )
 }


### PR DESCRIPTION
## Summary
- toggle cart drawer from navbar button instead of link
- control cart drawer visibility via open state with close callbacks
- import React in empty state for test environment

## Testing
- `cd var/www/medusa-backend && npm test`
- `cd var/www/frontend-next && npm test`

------
https://chatgpt.com/codex/tasks/task_b_689e4bc2debc8321aaf6a01581f3598c