### PR TITLE
fix cart drawer z-index layering

### DIFF
--- a/var/www/frontend-next/components/CartDrawer.tsx
+++ b/var/www/frontend-next/components/CartDrawer.tsx
@@ -26,13 +26,13 @@ export default function CartDrawer({ open, onClose }: Props) {
   return (
     <>
       <div
-        className={`fixed inset-0 bg-black transition-opacity duration-300 ${
+        className={`fixed inset-0 z-40 bg-black transition-opacity duration-300 ${
           open ? 'bg-opacity-50' : 'bg-opacity-0 pointer-events-none'
         }`}
         onClick={onClose}
       />
       <aside
-        className={`fixed right-0 top-0 w-80 h-screen bg-white shadow-md p-4 space-y-4 transform transition-transform duration-300 ${
+        className={`fixed right-0 top-0 z-50 w-80 h-screen bg-white shadow-md p-4 space-y-4 transform transition-transform duration-300 ${
           open ? 'translate-x-0' : 'translate-x-full'
         }`}
       >


### PR DESCRIPTION
## Summary
- ensure cart drawer has solid background and higher z-index than backdrop
- place z-indexed backdrop under drawer for proper layering

## Testing
- `npm test` in `var/www/frontend-next`
- `npm test` in `var/www/medusa-backend`


------
https://chatgpt.com/codex/tasks/task_b_689e5f90512c8321a19b686c0cf953f6