### PR TITLE
style: add left wipe underline animation

### DIFF
--- a/var/www/frontend-next/app/globals.css
+++ b/var/www/frontend-next/app/globals.css
@@ -67,24 +67,35 @@
   animation: heroZoom 2000ms ease-out both;
 }
 
-.underline-from-center {
+.underline-wipe-left {
   position: relative;
 }
 
-.underline-from-center::after {
+.underline-wipe-left::after {
   content: '';
   position: absolute;
+  left: 0;
   bottom: -2px;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 0;
-  height: 2px;
+  width: 100%;
+  height: 1px;
   background-color: currentColor;
-  transition: width 300ms ease;
 }
 
-.underline-from-center:hover::after {
+.underline-wipe-left::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  bottom: -2px;
   width: 100%;
+  height: 1px;
+  background-color: currentColor;
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 300ms ease;
+}
+
+.underline-wipe-left:hover::before {
+  transform: scaleX(1);
 }
 
 .swiper,

--- a/var/www/frontend-next/components/LookbookCarouselClient.tsx
+++ b/var/www/frontend-next/components/LookbookCarouselClient.tsx
@@ -33,7 +33,7 @@ export default function LookbookCarouselClient({ items }: { items: LookbookItem[
                 </h2>
                 <Link
                   href='/shop'
-                  className='underline-from-center text-3xl md:text-4xl font-bold tracking-brand'
+                  className='underline-wipe-left text-3xl md:text-4xl font-bold tracking-brand'
                 >
                   Shop Now
                 </Link>


### PR DESCRIPTION
## Summary
- add persistent underline and left-to-right wipe animation
- update lookbook carousel link to use new underline style

## Testing
- `npm test` in var/www/medusa-backend


------
https://chatgpt.com/codex/tasks/task_b_689fd48faf248321bf88176b16062e29