### PR TITLE
feat: update continue shopping links

### DIFF
--- a/var/www/frontend-next/app/cart/page.tsx
+++ b/var/www/frontend-next/app/cart/page.tsx
@@ -90,7 +90,7 @@ export default function CartPage() {
             <span className='text-xl'>${totalPrice().toFixed(2)}</span>
           </div>
           <div className='flex gap-4 pt-4'>
-            <Link href='/' className='px-4 py-2 border border-black rounded-md'>
+            <Link href='/shop' className='px-4 py-2 border border-black rounded-md'>
               Continue Shopping
             </Link>
             <Link

--- a/var/www/frontend-next/components/CartEmptyState.tsx
+++ b/var/www/frontend-next/components/CartEmptyState.tsx
@@ -25,7 +25,7 @@ export default function CartEmptyState({ show = false }: Props) {
     >
       <Image src='/logo.svg' alt='Empty cart' width={120} height={120} />
       <p className='text-xl font-semibold'>Your cart is empty</p>
-      <Link href='/' className='px-4 py-2 border border-black rounded-md'>
+      <Link href='/shop' className='px-4 py-2 border border-black rounded-md'>
         Continue Shopping
       </Link>
     </div>


### PR DESCRIPTION
## Summary
- direct cart empty state button to shop page
- route cart page continue shopping action to shop

## Testing
- `npm test`
- `curl -I http://localhost:3000/shop`
- `curl -s http://localhost:3000/cart | grep -o 'href="/shop"' | head -n 20`


------
https://chatgpt.com/codex/tasks/task_b_689fd68ece6c8321975125774ad1f2af