### PR TITLE
chore: point medusa backend to localhost 7001

### DIFF
--- a/var/www/medusa-backend/.env.template
+++ b/var/www/medusa-backend/.env.template
@@ -3,8 +3,8 @@ NODE_ENV=production
 MEDUSA_ADMIN_CORS=http://localhost:7001
 MEDUSA_STORE_CORS=http://localhost:3000
 # Public URLs used by the Admin to talk to the backend
-MEDUSA_BACKEND_URL=http://localhost:9000
-MEDUSA_ADMIN_URL=http://localhost:7001
+MEDUSA_BACKEND_URL=http://localhost:7001
+MEDUSA_ADMIN_BACKEND_URL=http://localhost:7001
 DATABASE_URL=postgres://postgres:postgres@db:5432/medusa
 REDIS_URL=redis://redis:6379
 JWT_SECRET=supersecret


### PR DESCRIPTION
## Summary
- update Medusa backend env template URLs to run on localhost:7001

## Testing
- `cd var/www/medusa-backend && npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a13386a584832189fa197bc782e84a