### PR TITLE
Remove Medusa from PM2 config and document Docker dev workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,33 @@ The services will be available at:
 
 A sample seed file is included for Medusa in `medusa-backend/data/seed.json`.
 
+## Local Development
+
+The Medusa backend, database, Redis and a development Nginx proxy run inside Docker:
+
+```bash
+cd var/www/medusa-backend
+docker compose up
+```
+
+The Nginx service in the Compose file exposes port 80 and forwards requests to Medusa,
+so do not start the host Nginx when using this setup.
+
+Run the frontend and Sanity Studio locally:
+
+```bash
+# Frontend
+cd var/www/frontend-next
+yarn dev
+
+# Sanity Studio
+cd var/www/sanity-studio
+yarn dev
+```
+
+Infrastructure services run in Docker while the Next.js frontend and Sanity Studio
+run on your machine.
+
 ## Admin UI
 
 The Medusa backend now serves the admin dashboard at `/app/`. The `/admin/`

--- a/var/www/server-config/pm2-universe.json
+++ b/var/www/server-config/pm2-universe.json
@@ -5,12 +5,6 @@
       "cwd": "/var/www/frontend-next",
       "script": "npm",
       "args": "start"
-    },
-    {
-      "name": "medusa",
-      "cwd": "/var/www/medusa-backend",
-      "script": "npm",
-      "args": "start"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- drop Medusa from PM2 configuration, leaving only the frontend
- document local development using Docker Compose for Medusa (with its own Nginx) while running the frontend and Sanity locally

## Testing
- `npm test` (within var/www/medusa-backend)`

------
https://chatgpt.com/codex/tasks/task_b_68a13655153c83219cd3cb69d5b6b825