### PR TITLE
chore: remove localhost 9000 remote pattern

### DIFF
--- a/var/www/frontend-next/next.config.js
+++ b/var/www/frontend-next/next.config.js
@@ -14,12 +14,6 @@ const nextConfig = {
         pathname: '/**'
       },
       {
-        protocol: 'http',
-        hostname: 'localhost',
-        port: '9000',
-        pathname: '/uploads/**'
-      },
-      {
         protocol: 'https',
         hostname: 'cdn.sanity.io',
         pathname: '/**'


### PR DESCRIPTION
## Summary
- remove localhost:9000 remote image pattern from Next.js config
- allow images only from localhost:7001 and cdn.sanity.io

## Testing
- `cd var/www/medusa-backend && npm test >/tmp/test.log && tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_b_68a1383752588321807f732d5660fe7b