### PR TITLE
Remove static underline from Shop Now link

### DIFF
--- a/var/www/frontend-next/app/globals.css
+++ b/var/www/frontend-next/app/globals.css
@@ -69,17 +69,7 @@
 
 .underline-wipe-left {
   position: relative;
-}
-
-.underline-wipe-left::after {
-  content: '';
-  position: absolute;
-  left: 0;
-  bottom: -2px;
-  width: 100%;
-  height: 1px;
-  background-color: currentColor;
-  z-index: 0;
+  text-decoration: none;
 }
 
 .underline-wipe-left::before {


### PR DESCRIPTION
## Summary
- remove permanent line from `underline-wipe-left`
- ensure link has no underline by default and animates on hover

## Testing
- `cd var/www/medusa-backend && npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a27b2a6a6c83219ffc1475505c0c4f