### PR TITLE
Refine cart layout and empty state styling

### DIFF
--- a/var/www/frontend-next/app/cart/page.tsx
+++ b/var/www/frontend-next/app/cart/page.tsx
@@ -15,8 +15,8 @@ export default function CartPage() {
   }, [items.length])
 
   return (
-    <main className="p-8 space-y-4">
-      <h1 className="text-3xl font-bold mb-4 tracking-brand">Cart</h1>
+    <main className='max-w-screen-md mx-auto p-4 md:p-8 space-y-4'>
+      <h1 className='text-2xl md:text-3xl font-bold mb-4 tracking-tight'>Cart</h1>
       <CartEmptyState show={showEmpty} />
       {!showEmpty && (
         <>
@@ -46,10 +46,10 @@ export default function CartPage() {
                         <span className="font-medium">{item.title}</span>
                       </div>
                     </td>
-                    <td className="p-2">
-                      <div className="flex items-center border rounded w-max">
+                    <td className='p-2'>
+                      <div className='flex items-center border border-gray-300 rounded w-max'>
                         <button
-                          className="px-2"
+                          className='px-2'
                           onClick={() =>
                             updateQuantity(item.id, item.quantity - 1)
                           }
@@ -58,16 +58,16 @@ export default function CartPage() {
                           -
                         </button>
                         <input
-                          type="number"
+                          type='number'
                           min={1}
                           value={item.quantity}
                           onChange={(e) =>
                             updateQuantity(item.id, parseInt(e.target.value))
                           }
-                          className="w-12 text-center border-l border-r"
+                          className='w-12 text-center border-l border-r border-gray-300'
                         />
                         <button
-                          className="px-2"
+                          className='px-2'
                           onClick={() =>
                             updateQuantity(item.id, item.quantity + 1)
                           }
@@ -98,16 +98,16 @@ export default function CartPage() {
             <span>Subtotal ({totalItems()} items)</span>
             <span className="text-xl">${totalPrice().toFixed(2)}</span>
           </div>
-          <div className="flex gap-4 pt-4">
+          <div className='flex gap-4 pt-4'>
             <Link
-              href="/shop"
-              className="px-4 py-2 border border-black rounded-md"
+              href='/shop'
+              className='px-4 py-2 border border-gray-300 rounded-md text-gray-600'
             >
               Continue Shopping
             </Link>
             <Link
-              href="/checkout"
-              className="px-4 py-2 bg-accent text-white rounded-md hover:bg-accent/90"
+              href='/checkout'
+              className='px-4 py-2 bg-accent text-white rounded-md hover:bg-accent/90'
             >
               Checkout
             </Link>

--- a/var/www/frontend-next/components/CartEmptyState.tsx
+++ b/var/www/frontend-next/components/CartEmptyState.tsx
@@ -21,11 +21,11 @@ export default function CartEmptyState({ show = false }: Props) {
 
   return (
     <div
-      className={`flex flex-col items-center justify-center py-20 space-y-6 text-center transition-all duration-200 transform ${show ? 'opacity-100 scale-100' : 'opacity-0 scale-95'} ${render ? '' : 'hidden'}`}
+      className={`flex flex-col items-center justify-center py-8 space-y-6 text-center transition-all duration-200 transform ${show ? 'opacity-100 scale-100' : 'opacity-0 scale-95'} ${render ? '' : 'hidden'}`}
     >
-      <Image src="/logo.svg" alt="Empty cart" width={120} height={120} />
-      <p className="text-xl font-semibold">Your cart is empty</p>
-      <Link href="/shop" className="px-4 py-2 border border-black rounded-md">
+      <Image src='/logo.svg' alt='Empty cart' width={120} height={120} />
+      <p className='text-xl font-semibold text-gray-600'>Your cart is empty</p>
+      <Link href='/shop' className='px-4 py-2 border border-gray-300 rounded-md text-gray-600'>
         Continue Shopping
       </Link>
     </div>


### PR DESCRIPTION
## Summary
- Center cart page content with responsive padding and tighter heading tracking
- Soften inactive borders and text, and reduce spacing in empty cart view

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a7ae7999e883219583332831a34962