### PR TITLE
style: refine empty cart spacing and colors

### DIFF
--- a/var/www/frontend-next/components/CartEmptyState.tsx
+++ b/var/www/frontend-next/components/CartEmptyState.tsx
@@ -21,11 +21,11 @@ export default function CartEmptyState({ show = false }: Props) {
 
   return (
     <div
-      className={`flex flex-col items-center justify-center py-8 space-y-6 text-center transition-all duration-200 transform ${show ? 'opacity-100 scale-100' : 'opacity-0 scale-95'} ${render ? '' : 'hidden'}`}
+      className={`flex flex-col items-center justify-center pt-20 pb-8 space-y-6 text-center transition-all duration-200 transform ${show ? 'opacity-100 scale-100' : 'opacity-0 scale-95'} ${render ? '' : 'hidden'}`}
     >
       <Image src='/logo.svg' alt='Empty cart' width={120} height={120} />
-      <p className='text-xl font-semibold text-gray-600'>Your cart is empty</p>
-      <Link href='/shop' className='px-4 py-2 border border-gray-300 rounded-md text-gray-600'>
+      <p className='text-xl font-semibold text-gray-500'>Your cart is empty</p>
+      <Link href='/shop' className='px-4 py-2 border border-gray-300 rounded-md text-gray-500'>
         Continue Shopping
       </Link>
     </div>


### PR DESCRIPTION
## Summary
- add generous top padding to empty cart state
- soften empty cart text color to gray

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a7af7192448321ab944cde8c6ca8b8