### PR TITLE
Use item IDs for cart keys and validate quantity input

### DIFF
--- a/var/www/frontend-next/app/cart/page.tsx
+++ b/var/www/frontend-next/app/cart/page.tsx
@@ -32,8 +32,8 @@ export default function CartPage() {
                 </tr>
               </thead>
               <tbody>
-                {items.map((item, i) => (
-                  <tr key={i} className="border-b border-gray-200">
+                {items.map((item) => (
+                  <tr key={item.id} className="border-b border-gray-200">
                     <td className="p-2">
                       <div className="flex items-center gap-4">
                         <Image
@@ -61,9 +61,14 @@ export default function CartPage() {
                           type='number'
                           min={1}
                           value={item.quantity}
-                          onChange={(e) =>
-                            updateQuantity(item.id, parseInt(e.target.value))
-                          }
+                          onChange={(e) => {
+                            const value = parseInt(e.target.value, 10)
+                            if (isNaN(value) || value < 1) {
+                              updateQuantity(item.id, 1)
+                            } else {
+                              updateQuantity(item.id, value)
+                            }
+                          }}
                           className='w-12 text-center border-l border-r border-gray-300'
                         />
                         <button

--- a/var/www/frontend-next/components/CartDrawer.tsx
+++ b/var/www/frontend-next/components/CartDrawer.tsx
@@ -50,8 +50,8 @@ export default function CartDrawer({ open, onClose }: Props) {
         {!showEmpty && (
           <>
             <ul className="space-y-2">
-              {items.map((item, i) => (
-                <li key={i} className="flex items-center justify-between gap-2">
+              {items.map((item) => (
+                <li key={item.id} className="flex items-center justify-between gap-2">
                   <div className="flex items-center gap-2">
                     <Image
                       src={item.image}


### PR DESCRIPTION
## Summary
- Use `item.id` as key when rendering cart items to avoid index-based keys
- Validate quantity input with base-10 parsing and guard against invalid values

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a7b14435848321b7ae6ea7bfe3f661