### PR TITLE
feat: parameterize deploy script

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ var/www/
 2. Run the one-shot deployment script on your server:
 
 ```bash
-sudo bash server-config/deploy.sh
+cd server-config
+DOMAIN=example.com EMAIL=admin@example.com bash deploy.sh
 ```
 
 The services will be available at:

--- a/var/www/server-config/deploy.sh
+++ b/var/www/server-config/deploy.sh
@@ -1,6 +1,15 @@
 #!/bin/bash
 set -e
 
+DOMAIN="${DOMAIN:-$1}"
+EMAIL="${EMAIL:-$2}"
+
+if [ -z "$DOMAIN" ] || [ -z "$EMAIL" ]; then
+  echo 'Usage: DOMAIN=example.com EMAIL=admin@example.com bash deploy.sh'
+  echo '   or: bash deploy.sh example.com admin@example.com'
+  exit 1
+fi
+
 sudo apt update
 sudo apt install -y curl nginx docker.io docker-compose certbot python3-certbot-nginx
 
@@ -25,7 +34,7 @@ yarn build
 sudo ln -sf /var/www/server-config/nginx.conf /etc/nginx/sites-enabled/default
 sudo systemctl restart nginx
 
-sudo certbot --nginx --non-interactive --agree-tos -m you@example.com -d example.com || true
+sudo certbot --nginx --non-interactive --agree-tos -m "$EMAIL" -d "$DOMAIN" || true
 
 pm2 start /var/www/server-config/pm2-universe.json
 pm2 save


### PR DESCRIPTION
## Summary
- allow `deploy.sh` to accept DOMAIN and EMAIL via env vars or args
- document deploying with DOMAIN and EMAIL

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a7b4e4067c8321b4eb896a34bcc185