### PR TITLE
Fix mobile menu layering over hero

### DIFF
--- a/var/www/frontend-next/components/LookbookCarouselClient.tsx
+++ b/var/www/frontend-next/components/LookbookCarouselClient.tsx
@@ -18,7 +18,7 @@ export default function LookbookCarouselClient({
   const shouldLoop = items.length > 1
 
   return (
-    <section className="relative z-10 w-full aspect-[4/5] md:aspect-video overflow-hidden">
+    <section className="relative z-0 w-full aspect-[4/5] md:aspect-video overflow-hidden">
       <Swiper loop={shouldLoop} watchOverflow className="h-full w-full">
         {items.map((item, index) => (
           <SwiperSlide key={`${item.title}-${index}`} className="h-full">

--- a/var/www/frontend-next/components/MobileMenu.tsx
+++ b/var/www/frontend-next/components/MobileMenu.tsx
@@ -11,13 +11,13 @@ export default function MobileMenu({ open, onClose }: Props) {
   return (
     <>
       <div
-        className={`fixed inset-0 bg-black z-40 transition-opacity duration-300 ${
+        className={`fixed inset-0 bg-black z-[1000] transition-opacity duration-300 ${
           open ? 'bg-opacity-50' : 'bg-opacity-0 pointer-events-none'
         }`}
         onClick={onClose}
       />
       <aside
-        className={`fixed left-0 top-0 w-64 h-full bg-white z-50 shadow-md p-4 transform transition-transform duration-300 ${
+        className={`fixed left-0 top-0 w-64 h-full bg-white z-[1010] shadow-md p-4 transform transition-transform duration-300 ${
           open ? 'translate-x-0' : '-translate-x-full'
         }`}
       >


### PR DESCRIPTION
## Summary
- raise mobile menu backdrop to z-[1000] and drawer to z-[1010]
- reset Lookbook carousel section z-index so hero doesn't sit above overlay

## Testing
- `cd var/www/medusa-backend && npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b2ff2082088321a07fd1e35b3a72aa