### PR TITLE
chore: prevent horizontal scroll

### DIFF
--- a/var/www/frontend-next/app/globals.css
+++ b/var/www/frontend-next/app/globals.css
@@ -13,7 +13,7 @@
     scroll-behavior: smooth;
   }
   body {
-    @apply bg-white text-black font-body tracking-body font-light;
+    @apply bg-white text-black font-body tracking-body font-light overflow-x-hidden;
     font-optical-sizing: auto;
   }
   h1,


### PR DESCRIPTION
## Summary
- add Tailwind's overflow-x-hidden to body so pages don't scroll sideways

## Testing
- `npm test` (in var/www/medusa-backend)
- `npm run build` (fails: fetch failed during prerender)


------
https://chatgpt.com/codex/tasks/task_b_68b300a695a48321b521d68a8740afa9