### PR TITLE
feat(frontend): enrich palette and spacing for accessibility

### DIFF
--- a/var/www/frontend-next/app/globals.css
+++ b/var/www/frontend-next/app/globals.css
@@ -13,8 +13,11 @@
     scroll-behavior: smooth;
   }
   body {
-    @apply bg-white text-black font-body tracking-body font-light overflow-x-hidden;
+    @apply bg-white text-black font-body tracking-body font-light overflow-x-hidden leading-relaxed;
     font-optical-sizing: auto;
+  }
+  section {
+    @apply py-12 md:py-16;
   }
   h1,
   h2,

--- a/var/www/frontend-next/tailwind.config.js
+++ b/var/www/frontend-next/tailwind.config.js
@@ -5,7 +5,33 @@ module.exports = {
   content: ['./app/**/*.{js,ts,jsx,tsx}', './components/**/*.{js,ts,jsx,tsx}'],
   theme: {
     extend: {
-      colors,
+      colors: {
+        ...colors,
+        warm: {
+          50: '#fafaf9',
+          100: '#f5f5f4',
+          200: '#e7e5e4',
+          300: '#d6d3d1',
+          400: '#a8a29e',
+          500: '#78716c',
+          600: '#57534e',
+          700: '#44403c',
+          800: '#292524',
+          900: '#1c1917',
+        },
+        burgundy: {
+          50: '#fdf5f6',
+          100: '#f8e6e9',
+          200: '#f1ccd4',
+          300: '#e8aab7',
+          400: '#d46a8a',
+          500: '#800020',
+          600: '#660019',
+          700: '#4d0013',
+          800: '#33000d',
+          900: '#1a0006',
+        },
+      },
       borderRadius: radii,
       boxShadow: shadows,
       keyframes: {


### PR DESCRIPTION
## Summary
- add warm neutrals and burgundy accents to Tailwind theme
- increase base line-height and default section padding for breathing room
- verify color contrast and typography meet WCAG AA

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b30340878883219f8ce85020941de3