### PR TITLE
Add Our Story section

### DIFF
--- a/var/www/frontend-next/app/page.tsx
+++ b/var/www/frontend-next/app/page.tsx
@@ -1,5 +1,6 @@
 import LookbookCarousel from '../components/LookbookCarousel'
 import FeaturedProducts from '../components/FeaturedProducts'
+import OurStory from '../components/OurStory'
 
 export default function HomePage() {
   return (
@@ -11,6 +12,7 @@ export default function HomePage() {
         </h2>
         <FeaturedProducts />
       </section>
+      <OurStory />
     </main>
   )
 }

--- a/var/www/frontend-next/components/OurStory.tsx
+++ b/var/www/frontend-next/components/OurStory.tsx
@@ -1,0 +1,34 @@
+import Image from 'next/image'
+import Link from 'next/link'
+
+export default function OurStory() {
+  return (
+    <section className='bg-gray-50 py-16 px-4 md:py-24'>
+      <div className='container mx-auto grid grid-cols-1 md:grid-cols-2 gap-8 items-center'>
+        <div>
+          <Image
+            src='/placeholder.svg'
+            alt='Our brand story'
+            width={600}
+            height={400}
+            className='w-full h-auto object-cover'
+          />
+        </div>
+        <div>
+          <h2 className='text-2xl font-bold mb-4 tracking-brand'>Our Story</h2>
+          <p className='mb-6'>
+            Born from a passion for mindful design, our brand blends modern
+            aesthetics with ethical craftsmanship. Every piece reflects our
+            commitment to sustainability and timeless style.
+          </p>
+          <Link
+            href='/story'
+            className='inline-block bg-black text-white px-8 py-3 tracking-wide'
+          >
+            Learn more
+          </Link>
+        </div>
+      </div>
+    </section>
+  )
+}


### PR DESCRIPTION
## Summary
- Add `OurStory` component with brand photo, narrative, and CTA on a subtle background
- Integrate `OurStory` into the home page after `FeaturedProducts`

## Testing
- `cd var/www/medusa-backend && npm test`
- `cd var/www/frontend-next && npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b304469ee08321aacee56168b4fd1b