### PR TITLE
feat(frontend): add baseline underline for wipe animation

### DIFF
--- a/var/www/frontend-next/app/globals.css
+++ b/var/www/frontend-next/app/globals.css
@@ -75,6 +75,19 @@
   text-decoration: none;
 }
 
+.underline-wipe-left::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  bottom: -2px;
+  width: 100%;
+  height: 1px;
+  background-color: currentColor;
+  transform: scaleX(1);
+  transform-origin: left;
+  z-index: 0;
+}
+
 .underline-wipe-left::before {
   content: '';
   position: absolute;


### PR DESCRIPTION
## Summary
- add ::after baseline underline for persistent decoration
- ensure animated ::before overlay sits above baseline

## Testing
- `cd var/www/medusa-backend && npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b307bec1a08321935fc754157972ad