### PR TITLE
Add Shop dropdown with collections and categories

### DIFF
--- a/var/www/frontend-next/components/Navbar.tsx
+++ b/var/www/frontend-next/components/Navbar.tsx
@@ -9,12 +9,12 @@ import { FaBars, FaShoppingCart, FaSearch } from 'react-icons/fa'
 import { useCart } from '../lib/store'
 import SearchOverlay from './SearchOverlay'
 import CartDrawer from './CartDrawer'
+import ShopDropdown from './ShopDropdown'
 
 const MobileMenu = dynamic(() => import('./MobileMenu'), { ssr: false })
 
 const links = [
   { href: '/', label: 'Home' },
-  { href: '/shop', label: 'Shop' },
 ]
 
 export default function Navbar() {
@@ -87,6 +87,26 @@ export default function Navbar() {
                 </Link>
               )
             })}
+            <div className="relative group">
+              <Link
+                href="/shop"
+                aria-current={pathname.startsWith('/shop') ? 'page' : undefined}
+                className="relative px-2 py-1 block focus:outline-none"
+              >
+                <span
+                  className={`transition-all ${pathname.startsWith('/shop') ? 'font-bold' : ''} group-hover:tracking-brand group-hover:-translate-y-0.5`}
+                >
+                  Shop
+                </span>
+                <span className="absolute inset-0 rounded-full bg-accent/5 opacity-0 group-hover:opacity-100 transition-opacity" />
+                <span
+                  className={`absolute bottom-0 h-0.5 bg-accent transition-all origin-center ${pathname.startsWith('/shop') ? 'w-full' : 'w-0 group-hover:w-full'} left-1/2 -translate-x-1/2 rtl:left-auto rtl:right-1/2 rtl:translate-x-1/2`}
+                />
+              </Link>
+              <div className="absolute left-0 top-full mt-2 hidden group-hover:block group-focus-within:block">
+                <ShopDropdown />
+              </div>
+            </div>
           </div>
         </div>
         <div className="justify-self-center">

--- a/var/www/frontend-next/components/ShopDropdown.tsx
+++ b/var/www/frontend-next/components/ShopDropdown.tsx
@@ -1,0 +1,57 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { medusa } from '../lib/medusa'
+
+interface Collection {
+  id: string
+  title: string
+}
+
+interface Category {
+  id: string
+  name: string
+}
+
+export default function ShopDropdown() {
+  const [collections, setCollections] = useState<Collection[]>([])
+  const [categories, setCategories] = useState<Category[]>([])
+
+  useEffect(() => {
+    medusa.collections.list().then(({ collections }) => setCollections(collections))
+    medusa.productCategories
+      .list()
+      .then(({ product_categories }) => setCategories(product_categories))
+  }, [])
+
+  return (
+    <div className='bg-white rounded-md shadow-lg p-6 grid gap-6 md:grid-cols-2'>
+      <div>
+        <h3 className='mb-2 font-semibold'>Collections</h3>
+        <ul className='space-y-1'>
+          {collections.map((c) => (
+            <li key={c.id}>
+              <Link href={`/shop?collection=${c.id}`} className='hover:underline'>
+                {c.title}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div>
+        <h3 className='mb-2 font-semibold'>Categories</h3>
+        <ul className='space-y-1'>
+          {categories.map((cat) => (
+            <li key={cat.id}>
+              <Link href={`/shop?category=${cat.id}`} className='hover:underline'>
+                {cat.name}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add `ShopDropdown` component fetching collections and categories
- replace Shop link with hoverable dropdown in `Navbar`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b308f8fefc8321894f7de8e4ee1e55