### PR TITLE
feat: add shop section to mobile menu

### DIFF
--- a/var/www/frontend-next/components/MobileMenu.tsx
+++ b/var/www/frontend-next/components/MobileMenu.tsx
@@ -1,13 +1,36 @@
 'use client'
 import Link from 'next/link'
-import { FaTimes } from 'react-icons/fa'
+import { useEffect, useState } from 'react'
+import { FaTimes, FaChevronDown, FaChevronUp } from 'react-icons/fa'
+import { medusa } from '../lib/medusa'
 
 interface Props {
   open: boolean
   onClose: () => void
 }
 
+interface Collection {
+  id: string
+  title: string
+}
+
+interface Category {
+  id: string
+  name: string
+}
+
 export default function MobileMenu({ open, onClose }: Props) {
+  const [collections, setCollections] = useState<Collection[]>([])
+  const [categories, setCategories] = useState<Category[]>([])
+  const [shopOpen, setShopOpen] = useState(false)
+
+  useEffect(() => {
+    medusa.collections.list().then(({ collections }) => setCollections(collections))
+    medusa.productCategories
+      .list()
+      .then(({ product_categories }) => setCategories(product_categories))
+  }, [])
+
   return (
     <>
       <div
@@ -22,27 +45,68 @@ export default function MobileMenu({ open, onClose }: Props) {
         }`}
       >
         <button
-          className="absolute top-4 right-4 hover:text-white hover:bg-accent p-1 rounded-md"
+          className='absolute top-4 right-4 hover:text-white hover:bg-accent p-1 rounded-md'
           onClick={onClose}
-          aria-label="Close menu"
+          aria-label='Close menu'
         >
           <FaTimes />
         </button>
-        <nav className="mt-8 flex flex-col space-y-4">
+        <nav className='mt-8 flex flex-col space-y-4'>
           <Link
-            href="/"
-            className="hover:underline decoration-gray-300"
+            href='/'
+            className='hover:underline decoration-gray-300'
             onClick={onClose}
           >
             Home
           </Link>
-          <Link
-            href="/shop"
-            className="hover:underline decoration-gray-300"
-            onClick={onClose}
-          >
-            Shop
-          </Link>
+          <div>
+            <button
+              className='flex items-center justify-between w-full hover:underline decoration-gray-300'
+              onClick={() => setShopOpen((s) => !s)}
+              aria-expanded={shopOpen}
+              aria-controls='mobile-shop-section'
+            >
+              <span>Shop</span>
+              {shopOpen ? <FaChevronUp /> : <FaChevronDown />}
+            </button>
+            <div
+              id='mobile-shop-section'
+              className={`${shopOpen ? 'block' : 'hidden'} mt-2 pl-4 flex flex-col space-y-4`}
+            >
+              <div>
+                <h3 className='mb-1 font-semibold'>Collections</h3>
+                <ul className='space-y-1'>
+                  {collections.map((c) => (
+                    <li key={c.id}>
+                      <Link
+                        href={`/shop?collection=${c.id}`}
+                        className='hover:underline'
+                        onClick={onClose}
+                      >
+                        {c.title}
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+              <div>
+                <h3 className='mb-1 font-semibold'>Categories</h3>
+                <ul className='space-y-1'>
+                  {categories.map((cat) => (
+                    <li key={cat.id}>
+                      <Link
+                        href={`/shop?category=${cat.id}`}
+                        className='hover:underline'
+                        onClick={onClose}
+                      >
+                        {cat.name}
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          </div>
         </nav>
       </aside>
     </>


### PR DESCRIPTION
## Summary
- add medusa-powered shop list to mobile menu
- show collapsible shop section with collections and categories

## Testing
- `npm test` (medusa-backend)
- `npm test` (frontend-next, failed: React is not defined)


------
https://chatgpt.com/codex/tasks/task_b_68b315c79d508321b364bea14dfbe757