### PR TITLE
feat: add dynamic hero section

### DIFF
--- a/var/www/frontend-next/app/page.tsx
+++ b/var/www/frontend-next/app/page.tsx
@@ -1,11 +1,11 @@
-import LookbookCarousel from '../components/LookbookCarousel'
+import HomeHero from '../components/HomeHero'
 import FeaturedProducts from '../components/FeaturedProducts'
 import OurStory from '../components/OurStory'
 
 export default function HomePage() {
   return (
     <main>
-      <LookbookCarousel />
+      <HomeHero />
       <section className="relative z-0 container mx-auto px-4">
         <h2 className="text-2xl font-bold mt-4 mb-4 tracking-brand">
           Featured products

--- a/var/www/frontend-next/components/HomeHero.tsx
+++ b/var/www/frontend-next/components/HomeHero.tsx
@@ -1,0 +1,53 @@
+import Image from 'next/image'
+import Link from 'next/link'
+import { sanity } from '../lib/sanity'
+
+interface SiteSettings {
+  heroTagline?: string
+  heroCollectionId?: string
+}
+
+interface LookbookItem {
+  url: string
+}
+
+export default async function HomeHero() {
+  const [settings, lookbook]: [SiteSettings, LookbookItem] = await Promise.all([
+    sanity.fetch(`*[_type == "siteSettings"][0]{heroTagline, heroCollectionId}`),
+    sanity.fetch(`*[_type == "lookbookItem"]|order(order asc)[0]{"url": photo.asset->url}`),
+  ])
+
+  const collectionLink = settings?.heroCollectionId
+    ? `/shop?collection=${settings.heroCollectionId}`
+    : '/shop'
+
+  return (
+    <section className='relative w-full aspect-[4/5] md:aspect-video overflow-hidden'>
+      <Image
+        src={lookbook?.url || '/placeholder.svg'}
+        alt={settings?.heroTagline || 'Hero image'}
+        fill
+        sizes='100vw'
+        className='object-cover'
+        priority
+      />
+      <div className='absolute inset-0 flex flex-col items-center justify-center text-white text-center gap-2'>
+        <h1 className='text-3xl md:text-5xl font-bold tracking-brand'>NABD</h1>
+        <Link
+          href='/shop'
+          className='text-2xl md:text-4xl font-bold tracking-brand'
+        >
+          SHOP ALL
+        </Link>
+        {settings?.heroTagline && (
+          <Link
+            href={collectionLink}
+            className='text-lg md:text-2xl font-bold tracking-brand'
+          >
+            {settings.heroTagline}
+          </Link>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/var/www/frontend-next/components/ShopDropdown.tsx
+++ b/var/www/frontend-next/components/ShopDropdown.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import Link from 'next/link'
 import { medusa } from '../lib/medusa'
 

--- a/var/www/sanity-studio/schemas/siteSettings.js
+++ b/var/www/sanity-studio/schemas/siteSettings.js
@@ -4,6 +4,11 @@ export default {
   type: 'document',
   fields: [
     { name: 'heroTagline', title: 'Hero Tagline', type: 'string' },
+    {
+      name: 'heroCollectionId',
+      title: 'Featured Collection ID',
+      type: 'string',
+    },
     { name: 'contactEmail', title: 'Contact Email', type: 'string' },
     { name: 'instagramUrl', title: 'Instagram URL', type: 'url' },
   ],


### PR DESCRIPTION
## Summary
- add home hero section pulling featured collection from Sanity
- wire homepage to new hero
- allow Sanity to store featured collection ID

## Testing
- `npm test` (medusa-backend)
- `npm test` (frontend-next)


------
https://chatgpt.com/codex/tasks/task_b_68b31dab428c8321a9de4e0a59cf188c