### PR TITLE
fix: rename cart drawer heading

### DIFF
--- a/var/www/frontend-next/components/CartDrawer.tsx
+++ b/var/www/frontend-next/components/CartDrawer.tsx
@@ -37,7 +37,7 @@ export default function CartDrawer({ open, onClose }: Props) {
         }`}
       >
         <div className='flex items-center justify-between p-2 border-b border-gray-200'>
-          <h2 className='font-bold'>Your Cart</h2>
+          <h2 className='font-bold'>Cart.</h2>
           <button
             className='p-1 rounded-md text-black hover:bg-accent hover:text-white'
             onClick={onClose}


### PR DESCRIPTION
## Summary
- replace cart drawer header text with "Cart."
- confirm aria label for close button remains accurate

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b38fa68b248321b386a0651e83490a