### PR TITLE
style: make cart empty message uppercase

### DIFF
--- a/var/www/frontend-next/components/CartEmptyState.tsx
+++ b/var/www/frontend-next/components/CartEmptyState.tsx
@@ -22,7 +22,7 @@ export default function CartEmptyState({ show = false }: Props) {
     <div
       className={`flex flex-col items-center justify-center pt-20 pb-8 space-y-6 text-center transition-all duration-200 transform ${show ? 'opacity-100 scale-100' : 'opacity-0 scale-95'} ${render ? '' : 'hidden'}`}
     >
-      <p className='mt-6 text-xl font-semibold text-gray-500'>Your cart is empty</p>
+      <p className='mt-6 text-xl font-semibold text-gray-500 uppercase'>Your cart is empty</p>
       <Link href='/shop' className='px-4 py-2 border border-gray-300 rounded-md text-gray-500'>
         Continue Shopping
       </Link>


### PR DESCRIPTION
## Summary
- use Tailwind `uppercase` utility for empty-cart message

## Testing
- `npm test` (medusa-backend)
- `npm test` (frontend-next)


------
https://chatgpt.com/codex/tasks/task_b_68b390ca21bc832182db856223488148