### PR TITLE
Normalize admin lite backend URL when Medusa base includes /store

### DIFF
--- a/var/www/frontend-next/app/api/lite/_utils/backend.ts
+++ b/var/www/frontend-next/app/api/lite/_utils/backend.ts
@@ -19,6 +19,7 @@ export const getBackendBase = () => {
 }
 
 const ADMIN_SUFFIX_PATTERN = /\/admin(?:\/lite)?$/i
+const STORE_SUFFIX_PATTERN = /\/store$/i
 
 const ensureAdminBase = (base: string) => {
   const trimmed = base.trim()
@@ -26,7 +27,8 @@ const ensureAdminBase = (base: string) => {
     throw new Error('MEDUSA_BACKEND_URL not configured')
   }
   const withoutTrailingSlash = trimmed.replace(/\/+$/, '')
-  const normalizedRoot = withoutTrailingSlash.replace(ADMIN_SUFFIX_PATTERN, '')
+  const withoutStoreSuffix = withoutTrailingSlash.replace(STORE_SUFFIX_PATTERN, '')
+  const normalizedRoot = withoutStoreSuffix.replace(ADMIN_SUFFIX_PATTERN, '')
   return normalizedRoot + '/admin'
 }
 

--- a/var/www/frontend-next/tests/app/api/lite/backend-utils.test.ts
+++ b/var/www/frontend-next/tests/app/api/lite/backend-utils.test.ts
@@ -39,6 +39,15 @@ describe('buildAdminUrl', () => {
     expect(buildAdminUrl('lite/products')).toBe('https://medusa.example/admin/lite/products')
   })
 
+  it('normalizes backends that point at the store API', () => {
+    setBackend('https://medusa.example/store')
+    expect(buildAdminUrl('lite/products')).toBe('https://medusa.example/admin/lite/products')
+    setBackend('https://medusa.example/store/')
+    expect(buildAdminUrl('lite/products')).toBe('https://medusa.example/admin/lite/products')
+    setBackend('https://medusa.example/api/store')
+    expect(buildAdminUrl('lite/products')).toBe('https://medusa.example/api/admin/lite/products')
+  })
+
   it('normalizes paths that include an admin prefix', () => {
     setBackend('https://medusa.example')
     expect(buildAdminUrl('admin/auth')).toBe('https://medusa.example/admin/auth')


### PR DESCRIPTION
## Summary
- ensure the admin lite proxy strips trailing /store from configured Medusa backend URLs before appending /admin
- cover store-based backend URLs in the backend utilities test suite

## Testing
- yarn test tests/app/api/lite/backend-utils.test.ts

------
https://chatgpt.com/codex/tasks/task_b_68d043525a8c8321baf4f88c097c8e86