### PR TITLE
Ensure admin proxy uses production backend fallback

### DIFF
--- a/var/www/frontend-next/app/api/lite/_utils/backend.ts
+++ b/var/www/frontend-next/app/api/lite/_utils/backend.ts
@@ -1,5 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server'
 
+import {
+  DEFAULT_DEVELOPMENT_MEDUSA_BACKEND_URL,
+  DEFAULT_PRODUCTION_MEDUSA_BACKEND_URL,
+} from '../../../../lib/constants'
+
 export const ADMIN_COOKIE = 'admin_lite_token'
 
 const hopByHopHeaders = new Set([
@@ -12,10 +17,29 @@ const hopByHopHeaders = new Set([
   'trailer',
   'content-length',
   'accept-encoding',
+  'host',
 ])
 
+const normalizeEnvUrl = (value?: string | null) => {
+  if (!value) return undefined
+  const trimmed = value.trim()
+  return trimmed ? trimmed : undefined
+}
+
+const resolveDefaultBackend = () => {
+  const env = process.env.NODE_ENV
+  if (env === 'development' || env === 'test') {
+    return DEFAULT_DEVELOPMENT_MEDUSA_BACKEND_URL
+  }
+  return DEFAULT_PRODUCTION_MEDUSA_BACKEND_URL
+}
+
 export const getBackendBase = () => {
-  return process.env.MEDUSA_BACKEND_URL || process.env.NEXT_PUBLIC_MEDUSA_URL
+  return (
+    normalizeEnvUrl(process.env.MEDUSA_BACKEND_URL) ||
+    normalizeEnvUrl(process.env.NEXT_PUBLIC_MEDUSA_URL) ||
+    resolveDefaultBackend()
+  )
 }
 
 const ADMIN_SUFFIX_PATTERN = /\/admin(?:\/lite)?$/i

--- a/var/www/frontend-next/lib/constants.ts
+++ b/var/www/frontend-next/lib/constants.ts
@@ -1,0 +1,2 @@
+export const DEFAULT_DEVELOPMENT_MEDUSA_BACKEND_URL = 'http://localhost:7001'
+export const DEFAULT_PRODUCTION_MEDUSA_BACKEND_URL = 'https://medusa-backend-nabd.onrender.com'

--- a/var/www/frontend-next/lib/medusa.ts
+++ b/var/www/frontend-next/lib/medusa.ts
@@ -1,4 +1,20 @@
 import Medusa from '@medusajs/medusa-js'
+import {
+  DEFAULT_DEVELOPMENT_MEDUSA_BACKEND_URL,
+  DEFAULT_PRODUCTION_MEDUSA_BACKEND_URL,
+} from './constants'
 
-const medusaUrl = process.env.NEXT_PUBLIC_MEDUSA_URL || 'http://localhost:7001'
+const normalized = (value?: string | null) => {
+  if (!value) return ''
+  const trimmed = value.trim()
+  return trimmed
+}
+
+const fallbackMedusaUrl =
+  process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test'
+    ? DEFAULT_DEVELOPMENT_MEDUSA_BACKEND_URL
+    : DEFAULT_PRODUCTION_MEDUSA_BACKEND_URL
+
+const medusaUrl = normalized(process.env.NEXT_PUBLIC_MEDUSA_URL) || fallbackMedusaUrl
+
 export const medusa = new Medusa({ baseUrl: medusaUrl, maxRetries: 3 })

--- a/var/www/frontend-next/tests/app/api/lite/backend-utils.test.ts
+++ b/var/www/frontend-next/tests/app/api/lite/backend-utils.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it, beforeEach, afterEach } from 'vitest'
 import { buildAdminUrl } from '../../../../app/api/lite/_utils/backend'
 
 const ORIGINAL_BACKEND = process.env.MEDUSA_BACKEND_URL
+const ORIGINAL_NEXT_PUBLIC = process.env.NEXT_PUBLIC_MEDUSA_URL
+const ORIGINAL_NODE_ENV = process.env.NODE_ENV
 
 const setBackend = (value?: string) => {
   if (value === undefined) {
@@ -14,6 +16,7 @@ const setBackend = (value?: string) => {
 describe('buildAdminUrl', () => {
   beforeEach(() => {
     setBackend(undefined)
+    delete process.env.NEXT_PUBLIC_MEDUSA_URL
   })
 
   afterEach(() => {
@@ -22,6 +25,12 @@ describe('buildAdminUrl', () => {
     } else {
       process.env.MEDUSA_BACKEND_URL = ORIGINAL_BACKEND
     }
+    if (ORIGINAL_NEXT_PUBLIC === undefined) {
+      delete process.env.NEXT_PUBLIC_MEDUSA_URL
+    } else {
+      process.env.NEXT_PUBLIC_MEDUSA_URL = ORIGINAL_NEXT_PUBLIC
+    }
+    process.env.NODE_ENV = ORIGINAL_NODE_ENV
   })
 
   it('appends /admin when backend has no admin suffix', () => {
@@ -52,5 +61,18 @@ describe('buildAdminUrl', () => {
     setBackend('https://medusa.example')
     expect(buildAdminUrl('admin/auth')).toBe('https://medusa.example/admin/auth')
     expect(buildAdminUrl('/admin/auth')).toBe('https://medusa.example/admin/auth')
+  })
+
+  it('falls back to default production backend when env is missing', () => {
+    const originalEnv = process.env.NODE_ENV
+    process.env.NODE_ENV = 'production'
+    delete process.env.MEDUSA_BACKEND_URL
+    delete process.env.NEXT_PUBLIC_MEDUSA_URL
+
+    expect(buildAdminUrl('lite/products')).toBe(
+      'https://medusa-backend-nabd.onrender.com/admin/lite/products'
+    )
+
+    process.env.NODE_ENV = originalEnv
   })
 })


### PR DESCRIPTION
## Summary
- add shared constants for Medusa backend defaults and reuse them in the storefront client
- teach the admin proxy helper to trim env vars, ignore forwarded host headers, and fall back to the production Medusa URL when none are set
- extend the proxy utility tests to cover the new default resolution behaviour

## Testing
- yarn test *(fails: components/SearchOverlay/index.test.tsx > SearchOverlay > mirrors close button in RTL)*
- npm test *(fails: cannot install @swc/core-linux-x64-musl on glibc images)*

------
https://chatgpt.com/codex/tasks/task_b_68d05696f5788321b92056392ab47353