### PR TITLE
Fix admin lite token handling and image lint warnings

### DIFF
--- a/var/www/frontend-next/app/api/admin/lite/session/route.ts
+++ b/var/www/frontend-next/app/api/admin/lite/session/route.ts
@@ -333,8 +333,9 @@ export async function POST(req: NextRequest) {
   if (!accessToken) {
     const tokenResult = createAdminLiteToken(user)
     if (!tokenResult.ok) {
-      console.error('[admin-lite] Unable to issue Admin Lite token', tokenResult.message)
-      return NextResponse.json({ message: tokenResult.message }, { status: 500 })
+      const message = 'message' in tokenResult ? tokenResult.message : 'Unable to issue Admin Lite token'
+      console.error('[admin-lite] Unable to issue Admin Lite token', message)
+      return NextResponse.json({ message }, { status: 500 })
     }
     accessToken = tokenResult.token
     user = tokenResult.user
@@ -368,8 +369,10 @@ export async function GET(req: NextRequest) {
   if (verification.ok) {
     return NextResponse.json({ authenticated: true, user: verification.user })
   }
-  if (verification.expired) {
-    return unauthorized('Session expired')
+  if (!verification.ok) {
+    if ('expired' in verification && verification.expired) {
+      return unauthorized('Session expired')
+    }
   }
 
   const result = await fetchCurrentUser(token)

--- a/var/www/frontend-next/components/admin-lite/ProductImageManager.tsx
+++ b/var/www/frontend-next/components/admin-lite/ProductImageManager.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import Image from 'next/image'
 import { useState, type ChangeEvent } from 'react'
 import { redirectToLogin } from '../../lib/admin-lite'
 
@@ -78,8 +79,8 @@ export default function ProductImageManager({ images, thumbnail, onChange, onSel
       </div>
       <div className='grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4'>
         {images.map((url) => (
-          <div key={url} className='relative overflow-hidden rounded-lg border border-slate-200 bg-white shadow-sm'>
-            <img src={url} alt='' className='h-40 w-full object-cover' />
+          <div key={url} className='relative h-40 w-full overflow-hidden rounded-lg border border-slate-200 bg-white shadow-sm'>
+            <Image src={url} alt='Product image' fill className='object-cover' sizes='(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 25vw' />
             <div className='absolute inset-x-0 bottom-0 flex justify-between bg-black/60 px-2 py-1 text-xs text-white'>
               <button type='button' onClick={() => onSelectThumbnail(url)} className={thumbnail === url ? 'font-semibold uppercase' : ''}>
                 {thumbnail === url ? 'Thumbnail' : 'Set thumbnail'}


### PR DESCRIPTION
## Summary
- replace the manual <img> tag in the admin lite image manager with `next/image` for optimized rendering and lint compliance
- tighten token creation error handling and session verification so TypeScript can infer error branches and surface meaningful messages

## Testing
- `npx yarn@1.22.19 run build` *(fails: build hits external Sanity fetch that is unreachable in the container)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68d0776c707c8321b3e3380d2cb3e49b