### PR TITLE
Allow Admin Lite to fall back to Medusa JWT secret

### DIFF
--- a/var/www/frontend-next/app/api/admin/lite/session/route.ts
+++ b/var/www/frontend-next/app/api/admin/lite/session/route.ts
@@ -26,6 +26,10 @@ const cleanEnv = (value?: string | null) => {
   return trimmed ? trimmed : undefined
 }
 
+const resolveAdminLiteSecret = () => {
+  return cleanEnv(process.env.ADMIN_LITE_JWT_SECRET) || cleanEnv(process.env.JWT_SECRET)
+}
+
 const buildStaffName = (firstName: string | null, lastName: string | null, fallbackEmail: string) => {
   const parts = [firstName, lastName].filter((part) => typeof part === 'string' && part.trim()) as string[]
   if (parts.length) {
@@ -49,7 +53,7 @@ const extractPermissions = (user: any) => {
 }
 
 const createAdminLiteToken = (user: any): TokenCreationResult => {
-  const secret = cleanEnv(process.env.ADMIN_LITE_JWT_SECRET)
+  const secret = resolveAdminLiteSecret()
   if (!secret) {
     return { ok: false, message: 'Admin Lite token not configured' }
   }
@@ -109,7 +113,7 @@ const createAdminLiteToken = (user: any): TokenCreationResult => {
 }
 
 const verifyAdminLiteToken = (token: string): TokenVerificationResult => {
-  const secret = cleanEnv(process.env.ADMIN_LITE_JWT_SECRET)
+  const secret = resolveAdminLiteSecret()
   if (!secret) {
     return { ok: false, reason: 'secret-missing' }
   }

--- a/var/www/medusa-backend/src/api/admin/lite/middlewares/auth.js
+++ b/var/www/medusa-backend/src/api/admin/lite/middlewares/auth.js
@@ -26,6 +26,17 @@ const buildAllowedOriginMatchers = (raw) => {
 let cachedAllowedOrigins = buildAllowedOriginMatchers(process.env.ADMIN_LITE_ALLOWED_ORIGINS || '')
 let cachedAllowedOriginsRaw = process.env.ADMIN_LITE_ALLOWED_ORIGINS || ''
 
+const resolveSecret = () => {
+  const candidates = [process.env.ADMIN_LITE_JWT_SECRET, process.env.JWT_SECRET]
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string') {
+      const trimmed = candidate.trim()
+      if (trimmed) return trimmed
+    }
+  }
+  return null
+}
+
 const getAllowedOrigins = () => {
   const raw = process.env.ADMIN_LITE_ALLOWED_ORIGINS || ''
   if (raw !== cachedAllowedOriginsRaw) {
@@ -55,7 +66,7 @@ const matchesAllowedOrigin = (allowedOrigins, value) => {
 }
 
 module.exports = (req, res, next) => {
-  const secret = process.env.ADMIN_LITE_JWT_SECRET
+  const secret = resolveSecret()
   if (!secret) {
     const logger = req.scope && req.scope.resolve ? req.scope.resolve('logger') : null
     if (logger && logger.error) logger.error('Admin Lite JWT secret missing')

--- a/var/www/medusa-backend/test/admin-lite.test.js
+++ b/var/www/medusa-backend/test/admin-lite.test.js
@@ -576,4 +576,18 @@ module.exports = async () => {
     .set('Authorization', authHeader)
     .send({ action: 'unsupported' })
     .expect(400)
+
+  process.env.ADMIN_LITE_JWT_SECRET = ''
+  process.env.JWT_SECRET = 'fallback-secret'
+
+  const fallbackApp = buildApp()
+  const fallbackToken = jwt.sign(
+    { sub: 'staff_fallback', email: 'fallback@nabd.dhk', name: 'Fallback Staff' },
+    process.env.JWT_SECRET
+  )
+
+  await request(fallbackApp)
+    .get('/admin/lite/orders')
+    .set('Authorization', 'Bearer ' + fallbackToken)
+    .expect(200)
 }


### PR DESCRIPTION
## Summary
- allow the Admin Lite session API to reuse the Medusa JWT secret when a dedicated Admin Lite secret is absent
- resolve the Admin Lite middleware secret in the same way so requests remain authorized
- add a regression test that covers the fallback secret scenario

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d0892ddc6c8321a60a217eb7fc65f5