### PR TITLE
Propagate admin lite login errors

### DIFF
--- a/var/www/frontend-next/app/api/admin/lite/session/route.ts
+++ b/var/www/frontend-next/app/api/admin/lite/session/route.ts
@@ -113,8 +113,13 @@ export async function POST(req: NextRequest) {
 
   if (!upstream.ok) {
     const message = body?.message || 'Authentication failed'
+    const status = upstream.status >= 400 && upstream.status <= 599 ? upstream.status : 502
     console.error('[admin-lite] /admin/lite/session login failed', upstream.status, body)
-    return NextResponse.json({ message }, { status: 502 })
+    const payload: Record<string, unknown> = { message }
+    if (body && typeof body === 'object') {
+      payload.details = body
+    }
+    return NextResponse.json(payload, { status })
   }
 
   const token = typeof body?.token === 'string' ? body.token : ''


### PR DESCRIPTION
## Summary
- preserve the upstream status code from the Medusa backend when admin lite login fails
- include the backend response body as `details` to help debug authentication failures

## Testing
- `npm test` *(fails: Cannot find module 'express')*


------
https://chatgpt.com/codex/tasks/task_b_68d094d5252083218f82d4e223815ae8