### PR TITLE
Ensure Admin Lite proxy targets same origin

### DIFF
--- a/var/www/frontend-next/app/api/admin/lite/session/route.ts
+++ b/var/www/frontend-next/app/api/admin/lite/session/route.ts
@@ -57,17 +57,17 @@ const unauthorized = (req: NextRequest, message = 'Not authenticated') => {
   return res
 }
 
-const buildLiteSessionUrl = () => {
+const buildLiteSessionUrl = (req?: NextRequest) => {
   try {
-    return buildAdminUrl('lite/session')
+    return buildAdminUrl('lite/session', req)
   } catch (error) {
     console.error('[admin-lite] Backend not configured', error)
     return null
   }
 }
 
-const fetchBackendSession = async (token: string) => {
-  const url = buildLiteSessionUrl()
+const fetchBackendSession = async (req: NextRequest | null, token: string) => {
+  const url = buildLiteSessionUrl(req || undefined)
   if (!url) {
     return { status: 500, body: { message: 'MEDUSA_BACKEND_URL not configured' } }
   }
@@ -107,7 +107,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ message: 'Email and password are required' }, { status: 400 })
   }
 
-  const url = buildLiteSessionUrl()
+  const url = buildLiteSessionUrl(req)
   if (!url) {
     return NextResponse.json({ message: 'MEDUSA_BACKEND_URL not configured' }, { status: 500 })
   }
@@ -167,7 +167,7 @@ export async function GET(req: NextRequest) {
     return unauthorized(req)
   }
 
-  const result = await fetchBackendSession(token)
+  const result = await fetchBackendSession(req, token)
   if (result.status === 401) {
     return unauthorized(req, 'Session expired')
   }

--- a/var/www/frontend-next/app/api/lite/[...path]/route.ts
+++ b/var/www/frontend-next/app/api/lite/[...path]/route.ts
@@ -15,9 +15,9 @@ const unauthorized = () => {
   return res
 }
 
-const buildTargetUrl = (segments: string[] | undefined, search: string) => {
+const buildTargetUrl = (req: NextRequest, segments: string[] | undefined, search: string) => {
   const parts = segments && segments.length ? segments.join('/') : ''
-  const url = buildAdminUrl(parts)
+  const url = buildAdminUrl(parts, req)
   return url + search
 }
 
@@ -38,7 +38,7 @@ const proxy = async (req: NextRequest, context: { params: { path?: string[] } })
 
   let targetUrl: string
   try {
-    targetUrl = buildTargetUrl(context.params.path, req.nextUrl.search)
+    targetUrl = buildTargetUrl(req, context.params.path, req.nextUrl.search)
   } catch (error) {
     console.error('[admin-lite] Backend URL not configured', error)
     return NextResponse.json({ message: 'MEDUSA_BACKEND_URL not configured' }, { status: 500 })

--- a/var/www/frontend-next/app/api/lite/catalog/categories/route.ts
+++ b/var/www/frontend-next/app/api/lite/catalog/categories/route.ts
@@ -38,7 +38,7 @@ const forward = async (req: NextRequest, token: string, path: string, body: any)
 
   let response: Response
   try {
-    response = await fetch(buildAdminUrl(path), {
+    response = await fetch(buildAdminUrl(path, req), {
       method: 'POST',
       headers,
       body: JSON.stringify(body),

--- a/var/www/frontend-next/app/api/lite/catalog/collections/route.ts
+++ b/var/www/frontend-next/app/api/lite/catalog/collections/route.ts
@@ -38,7 +38,7 @@ const forward = async (req: NextRequest, token: string, path: string, body: any)
 
   let response: Response
   try {
-    response = await fetch(buildAdminUrl(path), {
+    response = await fetch(buildAdminUrl(path, req), {
       method: 'POST',
       headers,
       body: JSON.stringify(body),

--- a/var/www/frontend-next/app/api/lite/catalog/route.ts
+++ b/var/www/frontend-next/app/api/lite/catalog/route.ts
@@ -24,7 +24,7 @@ const fetchJson = async (
   path: string,
   options: FetchJsonOptions = {}
 ) => {
-  const url = buildAdminUrl(path)
+  const url = buildAdminUrl(path, req)
   let response: Response
   try {
     response = await fetch(url, {

--- a/var/www/frontend-next/app/api/lite/products/[id]/inventory/route.ts
+++ b/var/www/frontend-next/app/api/lite/products/[id]/inventory/route.ts
@@ -53,7 +53,7 @@ const buildUpstreamRequest = async (
   path: string,
   init: RequestInit = {}
 ) => {
-  const url = buildAdminUrl(path)
+  const url = buildAdminUrl(path, req)
   const headers = buildUpstreamHeaders(req, token, init.headers)
   if (init.body && !headers.has('content-type')) {
     headers.set('content-type', 'application/json')

--- a/var/www/frontend-next/app/api/lite/products/[id]/route.ts
+++ b/var/www/frontend-next/app/api/lite/products/[id]/route.ts
@@ -22,7 +22,7 @@ const forward = async (req: NextRequest, token: string, method: string, productI
     requestBody = JSON.stringify(body)
   }
 
-  const url = buildAdminUrl('lite/products/' + encodeURIComponent(productId))
+  const url = buildAdminUrl('lite/products/' + encodeURIComponent(productId), req)
 
   let response: Response
   try {

--- a/var/www/frontend-next/app/api/lite/products/route.ts
+++ b/var/www/frontend-next/app/api/lite/products/route.ts
@@ -22,7 +22,7 @@ const forward = async (req: NextRequest, token: string, method: string, body?: a
     requestBody = JSON.stringify(body)
   }
 
-  const url = buildAdminUrl('lite/products' + req.nextUrl.search)
+  const url = buildAdminUrl('lite/products' + req.nextUrl.search, req)
 
   let response: Response
   try {

--- a/var/www/frontend-next/tests/app/api/lite/backend-utils.test.ts
+++ b/var/www/frontend-next/tests/app/api/lite/backend-utils.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, beforeEach, afterEach } from 'vitest'
+import { NextRequest } from 'next/server'
 import { buildAdminUrl } from '../../../../app/api/lite/_utils/backend'
 
 const ORIGINAL_BACKEND = process.env.MEDUSA_BACKEND_URL
@@ -74,5 +75,21 @@ describe('buildAdminUrl', () => {
     )
 
     process.env.NODE_ENV = originalEnv
+  })
+
+  it('auto-detects same-origin backend when env is missing', () => {
+    delete process.env.MEDUSA_BACKEND_URL
+    delete process.env.NEXT_PUBLIC_MEDUSA_URL
+
+    const request = new NextRequest('https://frontend.nabd.dhk/api/admin/lite/session', {
+      headers: {
+        host: 'frontend.nabd.dhk',
+        'x-forwarded-proto': 'https',
+      },
+    })
+
+    expect(buildAdminUrl('lite/products', request)).toBe(
+      'https://frontend.nabd.dhk/admin/lite/products'
+    )
   })
 })


### PR DESCRIPTION
## Summary
- make the Admin Lite proxy build its Medusa base URL from MEDUSA_BACKEND_URL / NEXT_PUBLIC_MEDUSA_URL or the incoming request when env vars are absent so the target always lives under /admin
- pass the active request through every Admin Lite API proxy so shared helpers can reuse the same-origin detection
- document the end-to-end "Admin Lite login fix" runbook covering env vars, proxy deploy, admin reset, backend envs, and verification curl

## Testing
- yarn test *(fails: components/SearchOverlay/index.test.ts > mirrors close button in RTL)*
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d0b70f5cd483218cfab482a0b957ac