### PR TITLE
Ensure admin seeding runs after migrations

### DIFF
--- a/var/www/medusa-backend/package.json
+++ b/var/www/medusa-backend/package.json
@@ -6,7 +6,7 @@
     "seed": "npx medusa seed -f ./data/seed.json",
     "migrate": "npx medusa migrations run",
     "ensure:admin": "node ./scripts/ensure-admin.js || npx medusa user -e ${MEDUSA_ADMIN_EMAIL:-admin@nabd.dhk} -p ${MEDUSA_ADMIN_PASSWORD:-supersecret12345678} -f ${MEDUSA_ADMIN_FIRST:-Admin} -l ${MEDUSA_ADMIN_LAST:-User}",
-    "postdeploy": "yarn migrate && yarn ensure:admin || true",
+    "postdeploy": "yarn migrate && yarn ensure:admin",
     "test": "node test/test.js"
   },
   "dependencies": {

--- a/var/www/medusa-backend/scripts/migrate-and-start.js
+++ b/var/www/medusa-backend/scripts/migrate-and-start.js
@@ -27,6 +27,7 @@ const run = (command, args, options = {}) =>
 const start = async () => {
   const skipMigrations = String(process.env.MEDUSA_SKIP_MIGRATIONS || '').toLowerCase() === 'true'
   const medusaBin = resolveBin('medusa')
+  const ensureAdminScript = path.join(__dirname, 'ensure-admin.js')
 
   try {
     if (!skipMigrations) {
@@ -35,6 +36,9 @@ const start = async () => {
     } else {
       console.log('[admin-lite] Skipping migrations (MEDUSA_SKIP_MIGRATIONS=true)')
     }
+
+    console.log('[admin-lite] Ensuring admin user exists...')
+    await run(process.execPath, [ensureAdminScript])
 
     const extraArgs = process.argv.slice(2)
     const host = process.env.MEDUSA_HOST || '0.0.0.0'


### PR DESCRIPTION
## Summary
- invoke the ensure-admin script immediately after database migrations so startup stops if seeding fails
- let the Render postdeploy hook surface seeding errors by removing the `|| true` guard

## Testing
- npm test
- curl -i -X POST http://127.0.0.1:9000/admin/auth -H 'Content-Type: application/json' -d '{"email":"admin@nabd.dhk","password":"supersecret12345678"}'


------
https://chatgpt.com/codex/tasks/task_b_68d13083f1108321b6f96c8fa1587b26