### PR TITLE
Remove unsupported name flags from Medusa admin fallback

### DIFF
--- a/var/www/medusa-backend/docker-entrypoint.sh
+++ b/var/www/medusa-backend/docker-entrypoint.sh
@@ -68,12 +68,10 @@ if ! node ./scripts/ensure-admin.js; then
   echo "Node ensure-admin failed; falling back to Medusa CLI"
   ADMIN_EMAIL=${MEDUSA_ADMIN_EMAIL:-admin@nabd.dhk}
   ADMIN_PASSWORD=${MEDUSA_ADMIN_PASSWORD:-supersecret12345678}
-  ADMIN_FIRST=${MEDUSA_ADMIN_FIRST:-Admin}
-  ADMIN_LAST=${MEDUSA_ADMIN_LAST:-User}
   if command -v medusa >/dev/null 2>&1; then
-    medusa user -e "$ADMIN_EMAIL" -p "$ADMIN_PASSWORD" -f "$ADMIN_FIRST" -l "$ADMIN_LAST" || true
+    medusa user -e "$ADMIN_EMAIL" -p "$ADMIN_PASSWORD" || true
   else
-    npx medusa user -e "$ADMIN_EMAIL" -p "$ADMIN_PASSWORD" -f "$ADMIN_FIRST" -l "$ADMIN_LAST" || true
+    npx medusa user -e "$ADMIN_EMAIL" -p "$ADMIN_PASSWORD" || true
   fi
 fi
 

--- a/var/www/medusa-backend/package.json
+++ b/var/www/medusa-backend/package.json
@@ -5,7 +5,7 @@
     "start": "node ./scripts/migrate-and-start.js",
     "seed": "npx medusa seed -f ./data/seed.json",
     "migrate": "npx medusa migrations run",
-    "ensure:admin": "node ./scripts/ensure-admin.js || npx medusa user -e ${MEDUSA_ADMIN_EMAIL:-admin@nabd.dhk} -p ${MEDUSA_ADMIN_PASSWORD:-supersecret12345678} -f ${MEDUSA_ADMIN_FIRST:-Admin} -l ${MEDUSA_ADMIN_LAST:-User}",
+    "ensure:admin": "node ./scripts/ensure-admin.js || npx medusa user -e ${MEDUSA_ADMIN_EMAIL:-admin@nabd.dhk} -p ${MEDUSA_ADMIN_PASSWORD:-supersecret12345678}",
     "postdeploy": "yarn migrate && yarn ensure:admin",
     "test": "node test/test.js"
   },


### PR DESCRIPTION
## Summary
- update the ensure:admin script and Docker entrypoint fallback to omit unsupported first/last name flags when invoking the Medusa CLI
- rely on email and password only so the fallback commands align with the supported CLI options

## Testing
- npm test *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_b_68d1bf2603ec83218413b719efd09177