### PR TITLE
Use yarn ensure:admin in migrate-and-start

### DIFF
--- a/var/www/medusa-backend/scripts/migrate-and-start.js
+++ b/var/www/medusa-backend/scripts/migrate-and-start.js
@@ -27,7 +27,6 @@ const run = (command, args, options = {}) =>
 const start = async () => {
   const skipMigrations = String(process.env.MEDUSA_SKIP_MIGRATIONS || '').toLowerCase() === 'true'
   const medusaBin = resolveBin('medusa')
-  const ensureAdminScript = path.join(__dirname, 'ensure-admin.js')
 
   try {
     if (!skipMigrations) {
@@ -38,7 +37,7 @@ const start = async () => {
     }
 
     console.log('[admin-lite] Ensuring admin user exists...')
-    await run(process.execPath, [ensureAdminScript])
+    await run('yarn', ['ensure:admin'])
 
     const extraArgs = process.argv.slice(2)
     const host = process.env.MEDUSA_HOST || '0.0.0.0'


### PR DESCRIPTION
## Summary
- call the migrate-and-start script with `yarn ensure:admin` so the package.json fallback path runs when needed

## Testing
- npm test *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_b_68d1c25bbefc83218cbc368f431691ab