### PR TITLE
fix: ensure admin upsert resiliently

### DIFF
--- a/var/www/medusa-backend/package.json
+++ b/var/www/medusa-backend/package.json
@@ -5,7 +5,7 @@
     "start": "node ./scripts/migrate-and-start.js",
     "seed": "npx medusa seed -f ./data/seed.json",
     "migrate": "npx medusa migrations run",
-    "ensure:admin": "node ./scripts/ensure-admin.js || npx medusa user -e ${MEDUSA_ADMIN_EMAIL:-admin@nabd.dhk} -p ${MEDUSA_ADMIN_PASSWORD:-supersecret12345678}",
+    "ensure:admin": "node ./scripts/ensure-admin.js || node -e \"process.exit(0)\"",
     "postdeploy": "yarn migrate && yarn ensure:admin",
     "test": "node test/test.js"
   },

--- a/var/www/medusa-backend/scripts/migrate-and-start.js
+++ b/var/www/medusa-backend/scripts/migrate-and-start.js
@@ -37,7 +37,11 @@ const start = async () => {
     }
 
     console.log('[admin-lite] Ensuring admin user exists...')
-    await run('yarn', ['ensure:admin'])
+    try {
+      await run('yarn', ['ensure:admin'])
+    } catch (err) {
+      console.warn('[admin-lite] ensure:admin failed (non-fatal):', err?.message || err)
+    }
 
     const extraArgs = process.argv.slice(2)
     const host = process.env.MEDUSA_HOST || '0.0.0.0'


### PR DESCRIPTION
## Summary
- replace the ensure-admin seeder with a bcrypt-based upsert that works with varchar hashes and skips when required env vars are missing
- drop the Medusa CLI fallback in favour of a no-op exit when the JS upsert fails so it remains idempotent
- allow migrate-and-start to continue booting even if ensure:admin fails to avoid restart loops

## Testing
- npm test *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_b_68d1c691b3008321bb20fa50572e1ff2