### PR TITLE
Fix Admin Lite session auth fallback

### DIFF
--- a/var/www/medusa-backend/src/api/admin/lite/auth.js
+++ b/var/www/medusa-backend/src/api/admin/lite/auth.js
@@ -3,11 +3,36 @@ const { User } = require('@medusajs/medusa')
 const { generateAdminLiteToken } = require('./utils/token')
 
 const authenticateAdmin = async (scope, email, password) => {
+  if (!scope || typeof scope.resolve !== 'function') return null
   const manager = scope.resolve('manager')
   const authService = scope.resolve('authService')
-  return await manager.transaction(async (transactionManager) => {
-    return await authService.withTransaction(transactionManager).authenticate(email, password)
-  })
+  if (!manager || !authService) return null
+
+  try {
+    const result = await manager.transaction(async (transactionManager) => {
+      return await authService.withTransaction(transactionManager).authenticate(email, password)
+    })
+    if (!result || result.success === false) return null
+
+    const user = result && result.user ? result.user : result
+    if (!user || typeof user !== 'object') return null
+
+    const hasIdentifier = [user.id, user._id].some((value) => typeof value === 'string' && value.trim())
+    const emailCandidate = typeof user.email === 'string' ? user.email.trim() : ''
+    if (!hasIdentifier || !emailCandidate) return null
+
+    const tokenResult = generateAdminLiteToken(user)
+    if (!tokenResult.ok) {
+      const error = new Error(tokenResult.message || 'Admin Lite token creation failed')
+      error.code = 'ADMIN_LITE_TOKEN_ERROR'
+      throw error
+    }
+
+    return { token: tokenResult.token, user: tokenResult.user }
+  } catch (error) {
+    if (isUnauthorizedError(error)) return null
+    throw error
+  }
 }
 
 const isUnauthorizedError = (error) => {
@@ -34,8 +59,15 @@ const isUnauthorizedError = (error) => {
 }
 
 exports.createSession = async (req, res) => {
-  const rawEmail = typeof req.body?.email === 'string' ? req.body.email : ''
-  const email = String(rawEmail || '').trim().toLowerCase()
+  res.setHeader('x-admin-lite-session', 'hit')
+
+  console.log('[admin-lite] /session body', {
+    hasBody: !!req.body,
+    keys: Object.keys(req.body || {}),
+    email: req.body?.email,
+  })
+
+  const email = String(req.body?.email || '').trim().toLowerCase()
   const password = String(req.body?.password || '')
   if (!email || !password) {
     res.status(400).json({ message: 'Email and password are required' })
@@ -44,30 +76,14 @@ exports.createSession = async (req, res) => {
 
   const logger = req.scope && req.scope.resolve ? req.scope.resolve('logger') : null
 
-  let result = null
-  let authError = null
   try {
-    result = await authenticateAdmin(req.scope, email, password)
-  } catch (error) {
-    authError = error
-  }
-
-  if (result && result.success && result.user) {
-    const tokenResult = generateAdminLiteToken(result.user)
-    if (!tokenResult.ok) {
-      if (logger && logger.error) {
-        logger.error('Admin Lite token creation failed: ' + tokenResult.message)
-      }
-      res.status(500).json({ message: tokenResult.message })
+    const result = await authenticateAdmin(req.scope, email, password)
+    if (result) {
+      res.status(200).json(result)
       return
     }
-    res.status(200).json({ token: tokenResult.token, user: tokenResult.user })
-    return
-  }
-
-  const shouldFallback = authError ? isUnauthorizedError(authError) : true
-  if (authError && !shouldFallback) {
-    if (logger && logger.error) logger.error('Admin Lite login failed: ' + authError.message)
+  } catch (error) {
+    if (logger && logger.error) logger.error('Admin Lite login failed: ' + error.message)
     res.status(500).json({ message: 'Authentication failed' })
     return
   }
@@ -75,40 +91,46 @@ exports.createSession = async (req, res) => {
   try {
     const manager = req.scope && req.scope.resolve ? req.scope.resolve('manager') : null
     if (!manager || typeof manager.getRepository !== 'function') {
-      throw new Error('Entity manager unavailable for fallback authentication')
-    }
-    const userRepo = manager.getRepository(User)
-    let user = await userRepo.findOne({ where: { email } })
-    const trimmedRawEmail = typeof rawEmail === 'string' ? rawEmail.trim() : ''
-    if (!user && trimmedRawEmail && trimmedRawEmail !== email) {
-      user = await userRepo.findOne({ where: { email: trimmedRawEmail } })
-    }
-    if (!user || user.deleted_at) {
-      res.status(401).json({ message: 'Invalid credentials' })
+      if (logger && logger.warn) {
+        logger.warn('Admin Lite fallback skipped: entity manager unavailable')
+      }
+      res.status(401).send('Invalid credentials')
       return
     }
+
+    const repo = manager.getRepository(User)
+    const user = await repo.findOne({ where: { email } })
+    if (!user || user.deleted_at) {
+      res.status(401).send('Invalid credentials')
+      return
+    }
+
     const ok = await bcrypt.compare(password, user.password_hash || '')
     if (!ok) {
-      res.status(401).json({ message: 'Invalid credentials' })
+      res.status(401).send('Invalid credentials')
       return
     }
-    const fallbackUser = {
+
+    const fallbackName = `${user.first_name ?? 'Admin'} ${user.last_name ?? ''}`.trim()
+    const tokenResult = generateAdminLiteToken({
       id: user.id,
       email: user.email,
-      first_name:
-        typeof user.first_name === 'string' && user.first_name.trim() ? user.first_name.trim() : null,
-      last_name: typeof user.last_name === 'string' && user.last_name.trim() ? user.last_name.trim() : null,
+      first_name: user.first_name,
+      last_name: user.last_name,
       role: user.role || 'admin',
       metadata: user.metadata,
-    }
-    const tokenResult = generateAdminLiteToken(fallbackUser)
+      name: fallbackName,
+    })
+
     if (!tokenResult.ok) {
-      if (logger && logger.error) logger.error('Admin Lite token creation failed: ' + tokenResult.message)
+      if (logger && logger.error) {
+        logger.error('Admin Lite fallback token creation failed: ' + tokenResult.message)
+      }
       res.status(500).json({ message: tokenResult.message })
       return
     }
+
     res.status(200).json({ token: tokenResult.token, user: tokenResult.user })
-    return
   } catch (error) {
     if (logger && logger.error) logger.error('Admin Lite fallback login failed: ' + error.message)
     res.status(500).json({ message: 'Authentication failed' })

--- a/var/www/medusa-backend/src/api/admin/lite/index.js
+++ b/var/www/medusa-backend/src/api/admin/lite/index.js
@@ -12,14 +12,18 @@ const products = require('./products')
 const uploads = require('./uploads')
 
 const route = express.Router()
-const jsonBody = express.json({ limit: process.env.ADMIN_LITE_BODY_LIMIT || '1mb' })
+const bodyLimit = process.env.ADMIN_LITE_BODY_LIMIT || '1mb'
+const jsonBody = express.json({ limit: bodyLimit })
+const urlencodedBody = express.urlencoded({ extended: false })
 const uploadMiddleware = fileUpload({ dest: os.tmpdir() })
 
 module.exports = (rootRouter) => {
   rootRouter.use('/admin/lite', route)
+  route.use(jsonBody)
+  route.use(urlencodedBody)
   route.use(rateLimit)
-  route.post('/session-debug', jsonBody, sessionDebug)
-  route.post('/session', jsonBody, asyncHandler(auth.createSession))
+  route.post('/session-debug', sessionDebug)
+  route.post('/session', asyncHandler(auth.createSession))
   route.use(authenticateLite)
 
   route.get('/session', asyncHandler(auth.getSession))


### PR DESCRIPTION
## Summary
- apply JSON and urlencoded parsers to the Admin Lite router before the session endpoints and mount the session routes ahead of auth middleware
- update the Admin Lite session handler to normalize inputs, emit debug headers/logs, try Medusa auth first, and fall back to bcrypt with Admin Lite token generation
- handle missing entity manager during fallback by returning a 401 so failed logins stay consistent

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d1e3a757508321b109540a9e7fff4b