### PR TITLE
Add public admin-lite session endpoint and helper updates

### DIFF
--- a/var/www/frontend-next/app/api/admin/lite/session/route.ts
+++ b/var/www/frontend-next/app/api/admin/lite/session/route.ts
@@ -59,7 +59,7 @@ const unauthorized = (req: NextRequest, message = 'Not authenticated') => {
 
 const buildLiteSessionUrl = (req?: NextRequest) => {
   try {
-    return buildAdminUrl('lite/session', req)
+    return buildAdminUrl('admin-lite/session', req)
   } catch (error) {
     console.error('[admin-lite] Backend not configured', error)
     return null
@@ -91,7 +91,7 @@ const fetchBackendSession = async (req: NextRequest | null, token: string) => {
       cache: 'no-store',
     })
   } catch (error) {
-    console.error('[admin-lite] Unable to reach /admin/lite/session', error)
+    console.error('[admin-lite] Unable to reach /admin-lite/session', error)
     return { status: 502, body: { message: 'Unable to reach backend' } }
   }
 
@@ -131,7 +131,7 @@ export async function POST(req: NextRequest) {
       body: JSON.stringify({ email, password }),
     })
   } catch (error) {
-    console.error('[admin-lite] Failed to reach /admin/lite/session', error)
+    console.error('[admin-lite] Failed to reach /admin-lite/session', error)
     return NextResponse.json({ message: 'Unable to reach backend' }, { status: 502 })
   }
 
@@ -143,7 +143,7 @@ export async function POST(req: NextRequest) {
   if (!upstream.ok) {
     const message = body?.message || 'Authentication failed'
     const status = upstream.status >= 400 && upstream.status <= 599 ? upstream.status : 502
-    console.error('[admin-lite] /admin/lite/session login failed', upstream.status, body)
+    console.error('[admin-lite] /admin-lite/session login failed', upstream.status, body)
     const payload: Record<string, unknown> = { message }
     if (body && typeof body === 'object') {
       payload.details = body
@@ -153,7 +153,7 @@ export async function POST(req: NextRequest) {
 
   const token = typeof body?.token === 'string' ? body.token : ''
   if (!token) {
-    console.error('[admin-lite] /admin/lite/session response missing token', body)
+    console.error('[admin-lite] /admin-lite/session response missing token', body)
     return NextResponse.json({ message: 'Authentication failed' }, { status: 502 })
   }
 

--- a/var/www/frontend-next/tests/app/api/lite/backend-utils.test.ts
+++ b/var/www/frontend-next/tests/app/api/lite/backend-utils.test.ts
@@ -64,6 +64,17 @@ describe('buildAdminUrl', () => {
     expect(buildAdminUrl('/admin/auth')).toBe('https://medusa.example/admin/auth')
   })
 
+  it('allows targeting the public admin-lite namespace', () => {
+    setBackend('https://medusa.example')
+    expect(buildAdminUrl('admin-lite/session')).toBe('https://medusa.example/admin-lite/session')
+
+    setBackend('https://medusa.example/admin')
+    expect(buildAdminUrl('admin-lite/session')).toBe('https://medusa.example/admin-lite/session')
+
+    setBackend('https://medusa.example/admin/lite')
+    expect(buildAdminUrl('admin-lite/session')).toBe('https://medusa.example/admin-lite/session')
+  })
+
   it('falls back to default production backend when env is missing', () => {
     const originalEnv = process.env.NODE_ENV
     process.env.NODE_ENV = 'production'


### PR DESCRIPTION
## Summary
- expose the admin-lite session endpoints through a new public /admin-lite router while keeping the legacy /admin/lite routes in place
- let buildAdminUrl detect the public namespace, share the root normalization logic, and cover it with tests
- update the Next.js admin-lite session API to call the new namespace and adjust related logging

## Testing
- npm test *(fails: existing admin-lite session test expects 401 but backend returns 500 when the manager repository is unavailable)*
- yarn test *(fails: existing SearchOverlay RTL unit test unrelated to these changes)*

------
https://chatgpt.com/codex/tasks/task_b_68d319142a9c832190addd1a89c59951