### PR TITLE
Add Admin-Lite session probe to public route

### DIFF
--- a/var/www/medusa-backend/src/api/admin/lite/index.js
+++ b/var/www/medusa-backend/src/api/admin/lite/index.js
@@ -24,6 +24,8 @@ module.exports = (rootRouter) => {
   publicRoute.use(rateLimit)
   publicRoute.post('/session-debug', sessionDebug)
   publicRoute.post('/session', asyncHandler(auth.createSession))
+  publicRoute.get('/session', authenticateLite, asyncHandler(auth.getSession))
+  publicRoute.get('/ping', authenticateLite, (req, res) => res.json({ ok: true }))
 
   route.use(jsonBody)
   route.use(urlencodedBody)


### PR DESCRIPTION
## Summary
- expose authenticated GET `/admin-lite/session` for Admin-Lite tokens on the public router
- mirror the lightweight `/ping` probe on the public Admin-Lite router

## Testing
- npm test *(fails: expected 401 "Unauthorized", got 500 "Internal Server Error")*

------
https://chatgpt.com/codex/tasks/task_b_68d325c320a883219ce7de104a1e3ccb